### PR TITLE
Add contest filters

### DIFF
--- a/backend/src/utils/routing.rs
+++ b/backend/src/utils/routing.rs
@@ -25,7 +25,8 @@ enum Contest {
   ABC,
   ARC,
   AGC,
-  Other(String),
+  Other,
+  Prefix(String),
 }
 
 impl Contest {
@@ -36,8 +37,10 @@ impl Contest {
       Contest::ARC
     } else if id.starts_with("agc") {
       Contest::AGC
+    } else if id == "other" || id == "others" {
+      Contest::Other
     } else {
-      Contest::Other(id.to_string())
+      Contest::Prefix(id.to_string())
     }
   }
 }
@@ -82,6 +85,15 @@ fn with_cors_headers(mut res: Response<Body>) -> Response<Body> {
   res
 }
 
+fn contest_number(contest_id: &str) -> Option<u32> {
+  let number: String = contest_id
+    .chars()
+    .filter(|c| c.is_ascii_digit())
+    .collect();
+
+  number.parse().ok()
+}
+
 pub async fn router(req: Request<Body>, state: Arc<AppState>) -> Result<Response<Body>, Infallible> {
   let now= Local::now();
   let path = req.uri().path().to_string();
@@ -108,8 +120,17 @@ pub async fn router(req: Request<Body>, state: Arc<AppState>) -> Result<Response
           })
           .unwrap_or_default();
 
+        let contest_from: Option<u32> = params.get("contest_from").and_then(|s| s.parse().ok());
+        let contest_to: Option<u32> = params.get("contest_to").and_then(|s| s.parse().ok());
+
         if min > max {
           let mut bad_request = Response::new(Body::from("'min' cannot bt greater than 'max'."));
+          *bad_request.status_mut() = StatusCode::BAD_REQUEST;
+          return Ok(bad_request);
+        }
+
+        if contest_from.zip(contest_to).is_some_and(|(from, to)| from > to) {
+          let mut bad_request = Response::new(Body::from("'contest_from' cannot be greater than 'contest_to'."));
           *bad_request.status_mut() = StatusCode::BAD_REQUEST;
           return Ok(bad_request);
         }
@@ -126,8 +147,21 @@ pub async fn router(req: Request<Body>, state: Arc<AppState>) -> Result<Response
               Contest::ABC => p.contest_id.starts_with("abc"),
               Contest::ARC => p.contest_id.starts_with("arc"),
               Contest::AGC => p.contest_id.starts_with("agc"),
-              Contest::Other(s) => p.contest_id.starts_with(s),
+              Contest::Other => {
+                !p.contest_id.starts_with("abc")
+                  && !p.contest_id.starts_with("arc")
+                  && !p.contest_id.starts_with("agc")
+              }
+              Contest::Prefix(s) => p.contest_id.starts_with(s),
             })
+          })
+          .filter(|p| {
+            let Some(number) = contest_number(&p.contest_id) else {
+              return contest_from.is_none() && contest_to.is_none();
+            };
+
+            contest_from.is_none_or(|from| number >= from)
+              && contest_to.is_none_or(|to| number <= to)
           })
           .filter_map(|p| {
             state.problem_models.get(&p.id).and_then(|m| {

--- a/backend/tests/routing_test.rs
+++ b/backend/tests/routing_test.rs
@@ -13,12 +13,32 @@ fn build_test_state() -> Arc<AppState> {
         "abc001_a".to_string(),
         ProblemModel { difficulty: Some(1000.0) },
     );
+    problem_models.insert(
+        "abc212_a".to_string(),
+        ProblemModel { difficulty: Some(900.0) },
+    );
+    problem_models.insert(
+        "typical90_a".to_string(),
+        ProblemModel { difficulty: Some(700.0) },
+    );
 
-    let problems = vec![Problem {
-        id: "abc001_a".to_string(),
-        contest_id: "abc001".to_string(),
-        name: "A - Test Problem".to_string(),
-    }];
+    let problems = vec![
+        Problem {
+            id: "abc001_a".to_string(),
+            contest_id: "abc001".to_string(),
+            name: "A - Test Problem".to_string(),
+        },
+        Problem {
+            id: "abc212_a".to_string(),
+            contest_id: "abc212".to_string(),
+            name: "A - Alloy".to_string(),
+        },
+        Problem {
+            id: "typical90_a".to_string(),
+            contest_id: "typical90".to_string(),
+            name: "A - Other Contest".to_string(),
+        },
+    ];
 
     Arc::new(AppState {
         problems,
@@ -88,4 +108,43 @@ async fn test_random_range() {
     let diff = problem.difficulty;
 
     assert!(500.0 <= diff && diff <= 1500.0);
+}
+
+#[tokio::test]
+async fn test_contest_number_from() {
+    let (status, body) = build_and_send(Method::GET, "/?min=0&max=1500&contest=abc&contest_from=212").await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        id: String,
+        contest_id: String,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(problem.id, "abc212_a");
+    assert_eq!(problem.contest_id, "abc212");
+}
+
+#[tokio::test]
+async fn test_other_contest_filter() {
+    let (status, body) = build_and_send(Method::GET, "/?min=0&max=1500&contest=other").await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        contest_id: String,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(problem.contest_id, "typical90");
+}
+
+#[tokio::test]
+async fn test_contest_from_greater_than_to() {
+    let (status, body) = build_and_send(Method::GET, "/?contest_from=300&contest_to=200").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, "'contest_from' cannot be greater than 'contest_to'.");
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -13,12 +13,19 @@
 
   const MIN_DIFF: number = 0;
   const MAX_DIFF: number = 3854;
+  const CONTEST_OPTIONS = [
+    { label: "ABC", value: "abc" },
+    { label: "ARC", value: "arc" },
+    { label: "AGC", value: "agc" },
+    { label: "Other", value: "other" },
+  ] as const;
 
   let cachedInput : ClosedRange | null = loadLastInput();
   let currentInput : ClosedRange | null;
 
   let min_diff = $state<number>(cachedInput ? cachedInput.min : MIN_DIFF);
   let max_diff = $state<number>(cachedInput ? cachedInput.max : MAX_DIFF);
+  let selectedContests = $state<string[]>([]);
   
   /*
 	 * バリデーションチェック
@@ -47,7 +54,16 @@
 
     try {
       const API_URL = import.meta.env.VITE_API_URL;
-			const API_CONTENT = `${API_URL}/?min=${min_diff}&max=${max_diff}`;
+      const params = new URLSearchParams({
+        min: String(min_diff),
+        max: String(max_diff),
+      });
+
+      if (selectedContests.length > 0) {
+        params.set("contest", selectedContests.join(","));
+      }
+
+			const API_CONTENT = `${API_URL}/?${params.toString()}`;
       const res = await fetch(API_CONTENT);
 
 			// 条件にあう問題がなかった場合
@@ -89,6 +105,12 @@
 	const clickDialog = (result: boolean): void => {
 		isDialogOpen = !isDialogOpen;
 	}
+
+  const toggleContest = (contest: string): void => {
+    selectedContests = selectedContests.includes(contest)
+      ? selectedContests.filter((value) => value !== contest)
+      : [...selectedContests, contest];
+  }
 </script>
 
 <div class="w-full h-full">
@@ -115,6 +137,20 @@
           Pick
         {/if}
       </Button>
+    </div>
+
+    <div class="flex flex-wrap gap-2 mt-3" aria-label="Contest filters">
+      {#each CONTEST_OPTIONS as contest}
+        <label class="inline-flex items-center gap-2 rounded-md border border-base-stroke-default px-3 py-2 text-sm text-base-foreground-default">
+          <input
+            type="checkbox"
+            class="accent-primary"
+            checked={selectedContests.includes(contest.value)}
+            onchange={() => toggleContest(contest.value)}
+          />
+          <span class="text-sm">{contest.label}</span>
+        </label>
+      {/each}
     </div>
 
     {#if !loading && result !== null}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -26,6 +26,8 @@
   let min_diff = $state<number>(cachedInput ? cachedInput.min : MIN_DIFF);
   let max_diff = $state<number>(cachedInput ? cachedInput.max : MAX_DIFF);
   let selectedContests = $state<string[]>([]);
+  let contest_from = $state<string>("");
+  let contest_to = $state<string>("");
   
   /*
 	 * バリデーションチェック
@@ -38,6 +40,9 @@
     isMinusMinDiff: min_diff < 0,
     isMinusMaxDiff: max_diff < 0,
   });
+  let contestRoundError = $derived(
+    contest_from !== "" && contest_to !== "" && Number(contest_from) > Number(contest_to),
+  );
 
   let result = $state<Problem | null>(null);        // 取得した問題
   let errorMessage = $state<string | null>(null);   // 取得できなかった場合に入るエラー
@@ -45,7 +50,7 @@
 
   // Backend APIを呼び出して、条件にあう問題を1問取得する
   const sendQuery = async (): Promise<void> => {
-    if (errors.rangeError || errors.isMinusMinDiff || errors.isMinusMaxDiff) {
+    if (errors.rangeError || errors.isMinusMinDiff || errors.isMinusMaxDiff || contestRoundError) {
       return;
     }
 
@@ -61,6 +66,12 @@
 
       if (selectedContests.length > 0) {
         params.set("contest", selectedContests.join(","));
+      }
+      if (contest_from !== "") {
+        params.set("contest_from", contest_from);
+      }
+      if (contest_to !== "") {
+        params.set("contest_to", contest_to);
       }
 
 			const API_CONTENT = `${API_URL}/?${params.toString()}`;
@@ -111,6 +122,15 @@
       ? selectedContests.filter((value) => value !== contest)
       : [...selectedContests, contest];
   }
+
+  const handlePick = (): void => {
+    if (currentInput === null || contestRoundError) {
+      return;
+    }
+
+    cacheInput(currentInput);
+    sendQuery();
+  }
 </script>
 
 <div class="w-full h-full">
@@ -123,12 +143,14 @@
       <p class="text-destructive mb-2 text-sm">最高Diffが負の値になっています。</p>
     {:else if errors.isMinusMinDiff}
       <p class="text-destructive mb-2 text-sm">最低Diffが負の値になっています</p>
+    {:else if contestRoundError}
+      <p class="text-destructive mb-2 text-sm">開始回が終了回を超えています。</p>
     {/if}
 
     <div class="flex items-center gap-2">
       <Input type="number" placeholder="最低Diffを入力してください。" isErrors={errors} bind:value={min_diff} />
       <Input type="number" placeholder="最高Diffを入力してください。" isErrors={errors} bind:value={max_diff} />
-			<Button onclick={() =>{sendQuery(), cacheInput(currentInput!)}} class="shrink-0 w-24 h-12 flex justify-center items-center" disabled={loading}>
+			<Button onclick={handlePick} class="shrink-0 w-24 h-12 flex justify-center items-center" disabled={loading || errors.rangeError || errors.isMinusMinDiff || errors.isMinusMaxDiff || contestRoundError}>
         {#if loading}
           <div class="animate-spin [animation-duration: 1.05s]">
             <Loader size="1.5rem" />
@@ -151,6 +173,11 @@
           <span class="text-sm">{contest.label}</span>
         </label>
       {/each}
+    </div>
+
+    <div class="grid grid-cols-2 gap-2 mt-3">
+      <Input type="number" min="1" placeholder="開始回 例: 212" bind:value={contest_from} />
+      <Input type="number" min="1" placeholder="終了回 任意" bind:value={contest_to} />
     </div>
 
     {#if !loading && result !== null}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -163,14 +163,14 @@
 
     <div class="flex flex-wrap gap-2 mt-3" aria-label="Contest filters">
       {#each CONTEST_OPTIONS as contest}
-        <label class="inline-flex items-center gap-2 rounded-md border border-base-stroke-default px-3 py-2 text-xs text-base-foreground-default">
+        <label class="inline-flex items-center gap-2 rounded-md border border-base-stroke-default px-3 py-2 !text-[1rem] text-base-foreground-default">
           <input
             type="checkbox"
             class="accent-primary"
             checked={selectedContests.includes(contest.value)}
             onchange={() => toggleContest(contest.value)}
           />
-          <span class="text-xs">{contest.label}</span>
+          <span class="!text-[1rem]">{contest.label}</span>
         </label>
       {/each}
     </div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -163,14 +163,14 @@
 
     <div class="flex flex-wrap gap-2 mt-3" aria-label="Contest filters">
       {#each CONTEST_OPTIONS as contest}
-        <label class="inline-flex items-center gap-2 rounded-md border border-base-stroke-default px-3 py-2 text-sm text-base-foreground-default">
+        <label class="inline-flex items-center gap-2 rounded-md border border-base-stroke-default px-3 py-2 text-xs text-base-foreground-default">
           <input
             type="checkbox"
             class="accent-primary"
             checked={selectedContests.includes(contest.value)}
             onchange={() => toggleContest(contest.value)}
           />
-          <span class="text-sm">{contest.label}</span>
+          <span class="text-xs">{contest.label}</span>
         </label>
       {/each}
     </div>


### PR DESCRIPTION
## Summary

- Add contest type filters for ABC, ARC, AGC, and Other in the picker UI.
- Add backend filtering by contest round range using `contest_from` and `contest_to`.
- Add frontend inputs for contest round range.
- Cover contest round and Other filtering with routing tests.

## Validation

- `cargo test` in `backend`
- `./node_modules/.bin/svelte-check --tsconfig ./tsconfig.app.json` in `frontend`

## Notes

This PR covers the contest filtering work discussed for #38 and #29.