### PR TITLE
Fix contest round filtering

### DIFF
--- a/backend/src/utils/routing.rs
+++ b/backend/src/utils/routing.rs
@@ -85,13 +85,14 @@ fn with_cors_headers(mut res: Response<Body>) -> Response<Body> {
   res
 }
 
-fn contest_number(contest_id: &str) -> Option<u32> {
-  let number: String = contest_id
-    .chars()
-    .filter(|c| c.is_ascii_digit())
-    .collect();
+fn standard_contest_number(contest_id: &str) -> Option<u32> {
+  for prefix in ["abc", "arc", "agc"] {
+    if let Some(number) = contest_id.strip_prefix(prefix) {
+      return number.parse().ok();
+    }
+  }
 
-  number.parse().ok()
+  None
 }
 
 pub async fn router(req: Request<Body>, state: Arc<AppState>) -> Result<Response<Body>, Infallible> {
@@ -156,7 +157,7 @@ pub async fn router(req: Request<Body>, state: Arc<AppState>) -> Result<Response
             })
           })
           .filter(|p| {
-            let Some(number) = contest_number(&p.contest_id) else {
+            let Some(number) = standard_contest_number(&p.contest_id) else {
               return contest_from.is_none() && contest_to.is_none();
             };
 

--- a/backend/tests/routing_test.rs
+++ b/backend/tests/routing_test.rs
@@ -143,6 +143,20 @@ async fn test_other_contest_filter() {
 }
 
 #[tokio::test]
+async fn test_contest_number_filter_excludes_other_contests() {
+    let (status, body) = build_and_send(Method::GET, "/?min=0&max=1500&contest=other&contest_from=90").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    #[derive(serde::Deserialize)]
+    struct ErrorResponse {
+        message: String,
+    }
+
+    let err: ErrorResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(err.message, "指定Diff範囲に該当する問題がありませんでした");
+}
+
+#[tokio::test]
 async fn test_contest_from_greater_than_to() {
     let (status, body) = build_and_send(Method::GET, "/?contest_from=300&contest_to=200").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);


### PR DESCRIPTION
## Summary

- Restrict contest round parsing to standard AtCoder contest prefixes: `abc`, `arc`, and `agc`.
- Prevent round filters from accidentally matching numeric non-standard contest IDs such as Other contests.
- Add a routing test that verifies Other contests are excluded when a round filter is provided.

## Validation

- `cargo test` in `backend`