### PR TITLE
Fix Fly.io backend deploy workflow

### DIFF
--- a/.github/workflows/backend.deploy.yml
+++ b/.github/workflows/backend.deploy.yml
@@ -1,0 +1,29 @@
+name: Backend Deploy
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend.deploy.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: backend-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --remote-only --cwd backend

--- a/.github/workflows/json.fetch.yml
+++ b/.github/workflows/json.fetch.yml
@@ -1,4 +1,4 @@
-name: Update AtCoder Problems JSON and Deploy
+name: Update AtCoder Problems JSON
 
 on:
   schedule:
@@ -44,16 +44,3 @@ jobs:
             git push
           fi
         working-directory: backend/data
-        
-      - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to Fly.io
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: |
-          if git log -1 --pretty=%B | grep -q "chore: update problems json"; then
-            flyctl deploy --remote-only --cwd backend
-          else
-            echo "Skipping deployment as no files were changed."
-          fi


### PR DESCRIPTION
## Summary

- Add a dedicated Backend Deploy workflow for Fly.io deployments.
- Run the deploy workflow on `master` updates that touch `backend/**`, or by manual dispatch.
- Remove the broken Fly.io deploy step from the JSON update workflow so it only updates AtCoder problem data.

## Validation

- YAML files load successfully with Ruby `YAML.load_file`.

Closes #50