### PR TITLE
Fix Fly.io deploy command

### DIFF
--- a/.github/workflows/backend.deploy.yml
+++ b/.github/workflows/backend.deploy.yml
@@ -24,6 +24,7 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
+        working-directory: backend
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: flyctl deploy --remote-only --cwd backend
+        run: flyctl deploy --remote-only


### PR DESCRIPTION
## Summary

- Fix the Backend Deploy workflow to avoid the unsupported `flyctl deploy --cwd` flag.
- Run `flyctl deploy --remote-only` from the `backend` working directory instead.

## Validation

- `.github/workflows/backend.deploy.yml` loads successfully with Ruby `YAML.load_file`.

Fixes the deploy failure from #51.