### PR TITLE
Add activity calendar

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -61,6 +61,7 @@
   let loading = $state<boolean>(false); // 問題を取得中か否か
   let pickActivity = $state<PickActivity>(loadPickActivity());
   let activityCells = $derived(buildActivityCells(pickActivity));
+  let activityYear = new Date().getFullYear();
 
   // Backend APIを呼び出して、条件にあう問題を1問取得する
   const sendQuery = async (): Promise<void> => {
@@ -395,14 +396,19 @@
     <div class="relative left-1/2 mt-4 flex w-screen -translate-x-1/2 flex-col items-center gap-2">
       <Label class="!text-[1rem] !font-medium">Activity</Label>
       <div class="w-screen overflow-x-auto pb-1">
-        <div class="mx-auto grid w-max grid-flow-col grid-rows-7 gap-1">
-          {#each activityCells as cell}
-            <div
-              class={`h-3 w-3 rounded-sm border border-base-stroke-default ${activityClass(cell.level)}`}
-              title={`${cell.dateKey}: ${cell.count}`}
-              aria-label={`${cell.dateKey}: ${cell.count}`}
-            ></div>
-          {/each}
+        <div class="mx-auto flex w-max items-center gap-3">
+          <div class="grid grid-flow-col grid-rows-7 gap-1">
+            {#each activityCells as cell}
+              <div
+                class={`h-3 w-3 rounded-sm border border-base-stroke-default ${activityClass(cell.level)}`}
+                title={`${cell.dateKey}: ${cell.count}`}
+                aria-label={`${cell.dateKey}: ${cell.count}`}
+              ></div>
+            {/each}
+          </div>
+          <span class="!text-[0.875rem] text-base-foreground-muted">
+            {activityYear}
+          </span>
         </div>
       </div>
     </div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,7 +11,13 @@
     type ClosedRange,
     createValidRange,
   } from "./utils/types";
-  import { cacheInput, loadLastInput } from "./utils/cacher";
+  import {
+    cacheInput,
+    loadLastInput,
+    loadPickActivity,
+    recordPickActivity,
+    type PickActivity,
+  } from "./utils/cacher";
 
   // ============================================================
 
@@ -53,6 +59,7 @@
   let result = $state<Problem | null>(null); // 取得した問題
   let errorMessage = $state<string | null>(null); // 取得できなかった場合に入るエラー
   let loading = $state<boolean>(false); // 問題を取得中か否か
+  let pickActivity = $state<PickActivity>(loadPickActivity());
 
   // Backend APIを呼び出して、条件にあう問題を1問取得する
   const sendQuery = async (): Promise<void> => {
@@ -104,6 +111,7 @@
       const json: Problem = await res.json();
 
       setTimeout(() => {
+        pickActivity = recordPickActivity();
         result = json;
         loading = false;
       }, 1050);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -29,7 +29,6 @@
     { label: "AGC", value: "agc" },
     { label: "Other", value: "other" },
   ] as const;
-  const ACTIVITY_DAYS = 365;
 
   let cachedInput = loadLastInput();
   let currentInput: ClosedRange | null;
@@ -189,10 +188,13 @@
 
   function buildActivityCells(activity: PickActivity) {
     const today = new Date();
-    const start = new Date(today);
-    start.setDate(today.getDate() - (ACTIVITY_DAYS - 1));
+    const start = new Date(today.getFullYear(), 0, 1);
+    const end = new Date(today.getFullYear(), 11, 31);
+    const activityDays =
+      Math.floor((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000)) +
+      1;
 
-    return Array.from({ length: ACTIVITY_DAYS }, (_, index) => {
+    return Array.from({ length: activityDays }, (_, index) => {
       const date = new Date(start);
       date.setDate(start.getDate() + index);
       const dateKey = getDateKey(date);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -392,9 +392,9 @@
       </div>
     {/if}
 
-    <div class="mt-4 flex flex-col items-center gap-2">
+    <div class="relative left-1/2 mt-4 flex w-screen -translate-x-1/2 flex-col items-center gap-2">
       <Label class="!text-[1rem] !font-medium">Activity</Label>
-      <div class="w-full overflow-x-auto pb-1">
+      <div class="w-screen overflow-x-auto pb-1">
         <div class="mx-auto grid w-max grid-flow-col grid-rows-7 gap-1">
           {#each activityCells as cell}
             <div

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -113,7 +113,6 @@
       const json: Problem = await res.json();
 
       setTimeout(() => {
-        pickActivity = recordPickActivity();
         result = json;
         loading = false;
       }, 1050);
@@ -138,6 +137,10 @@
 
   const clickDialog = (result: boolean): void => {
     isDialogOpen = !isDialogOpen;
+  };
+
+  const markSolved = (): void => {
+    pickActivity = recordPickActivity();
   };
 
   const toggleContest = (contest: string): void => {
@@ -360,6 +363,14 @@
                 >Difficulty: {Math.floor(result!.difficulty)}</Label
               >
             </Dialog>
+
+            <Button
+              size="tiny"
+              variant="success"
+              tone="ghost"
+              class="mt-2"
+              onclick={markSolved}>解いた</Button
+            >
           </div>
         </Message>
       </div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -29,7 +29,7 @@
     { label: "AGC", value: "agc" },
     { label: "Other", value: "other" },
   ] as const;
-  const ACTIVITY_DAYS = 84;
+  const ACTIVITY_DAYS = 182;
 
   let cachedInput = loadLastInput();
   let currentInput: ClosedRange | null;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -60,8 +60,11 @@
   let errorMessage = $state<string | null>(null); // 取得できなかった場合に入るエラー
   let loading = $state<boolean>(false); // 問題を取得中か否か
   let pickActivity = $state<PickActivity>(loadPickActivity());
-  let activityCells = $derived(buildActivityCells(pickActivity));
-  let activityYear = new Date().getFullYear();
+  let selectedActivityYear = $state<number>(new Date().getFullYear());
+  let activityYears = $derived(buildActivityYears(pickActivity));
+  let activityCells = $derived(
+    buildActivityCells(pickActivity, selectedActivityYear),
+  );
 
   // Backend APIを呼び出して、条件にあう問題を1問取得する
   const sendQuery = async (): Promise<void> => {
@@ -187,10 +190,22 @@
     return `${year}-${month}-${day}`;
   }
 
-  function buildActivityCells(activity: PickActivity) {
-    const today = new Date();
-    const start = new Date(today.getFullYear(), 0, 1);
-    const end = new Date(today.getFullYear(), 11, 31);
+  function buildActivityYears(activity: PickActivity): number[] {
+    const currentYear = new Date().getFullYear();
+    const years = new Set(
+      Object.keys(activity).map((dateKey) => Number(dateKey.slice(0, 4))),
+    );
+
+    years.add(currentYear);
+
+    return Array.from(years)
+      .filter((year) => Number.isInteger(year))
+      .sort((a, b) => b - a);
+  }
+
+  function buildActivityCells(activity: PickActivity, year: number) {
+    const start = new Date(year, 0, 1);
+    const end = new Date(year, 11, 31);
     const activityDays =
       Math.floor((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000)) +
       1;
@@ -406,9 +421,21 @@
               ></div>
             {/each}
           </div>
-          <span class="!text-[0.875rem] text-base-foreground-muted">
-            {activityYear}
-          </span>
+          <div class="flex flex-col gap-1">
+            {#each activityYears as year}
+              <button
+                type="button"
+                class={`rounded-sm px-1 text-left !text-[0.875rem] ${
+                  selectedActivityYear === year
+                    ? "text-base-foreground-default"
+                    : "text-base-foreground-muted"
+                }`}
+                onclick={() => (selectedActivityYear = year)}
+              >
+                {year}
+              </button>
+            {/each}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -29,6 +29,7 @@
     { label: "AGC", value: "agc" },
     { label: "Other", value: "other" },
   ] as const;
+  const ACTIVITY_DAYS = 84;
 
   let cachedInput = loadLastInput();
   let currentInput: ClosedRange | null;
@@ -60,6 +61,7 @@
   let errorMessage = $state<string | null>(null); // 取得できなかった場合に入るエラー
   let loading = $state<boolean>(false); // 問題を取得中か否か
   let pickActivity = $state<PickActivity>(loadPickActivity());
+  let activityCells = $derived(buildActivityCells(pickActivity));
 
   // Backend APIを呼び出して、条件にあう問題を1問取得する
   const sendQuery = async (): Promise<void> => {
@@ -173,6 +175,50 @@
       contest_to: "",
     });
   };
+
+  function getDateKey(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+
+    return `${year}-${month}-${day}`;
+  }
+
+  function buildActivityCells(activity: PickActivity) {
+    const today = new Date();
+    const start = new Date(today);
+    start.setDate(today.getDate() - (ACTIVITY_DAYS - 1));
+
+    return Array.from({ length: ACTIVITY_DAYS }, (_, index) => {
+      const date = new Date(start);
+      date.setDate(start.getDate() + index);
+      const dateKey = getDateKey(date);
+      const count = activity[dateKey] ?? 0;
+
+      return {
+        dateKey,
+        count,
+        level: count === 0 ? 0 : Math.min(4, count),
+      };
+    });
+  }
+
+  function activityClass(level: number): string {
+    if (level === 0) {
+      return "bg-base-container-muted";
+    }
+    if (level === 1) {
+      return "bg-success/30";
+    }
+    if (level === 2) {
+      return "bg-success/50";
+    }
+    if (level === 3) {
+      return "bg-success/70";
+    }
+
+    return "bg-success";
+  }
 </script>
 
 <div class="w-full h-full">
@@ -332,6 +378,19 @@
         </Message>
       </div>
     {/if}
+
+    <div class="mt-4 flex flex-col gap-2">
+      <Label class="!text-[1rem] !font-medium">Activity</Label>
+      <div class="grid grid-flow-col grid-rows-7 gap-1 self-start">
+        {#each activityCells as cell}
+          <div
+            class={`h-3 w-3 rounded-sm border border-base-stroke-default ${activityClass(cell.level)}`}
+            title={`${cell.dateKey}: ${cell.count}`}
+            aria-label={`${cell.dateKey}: ${cell.count}`}
+          ></div>
+        {/each}
+      </div>
+    </div>
   </div>
 
   <footer class="fixed bottom-4 left-0 flex w-full justify-center">

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -392,16 +392,18 @@
       </div>
     {/if}
 
-    <div class="mt-4 flex flex-col gap-2">
+    <div class="mt-4 flex flex-col items-center gap-2">
       <Label class="!text-[1rem] !font-medium">Activity</Label>
-      <div class="grid grid-flow-col grid-rows-7 gap-1 self-start">
-        {#each activityCells as cell}
-          <div
-            class={`h-3 w-3 rounded-sm border border-base-stroke-default ${activityClass(cell.level)}`}
-            title={`${cell.dateKey}: ${cell.count}`}
-            aria-label={`${cell.dateKey}: ${cell.count}`}
-          ></div>
-        {/each}
+      <div class="w-full overflow-x-auto pb-1">
+        <div class="mx-auto grid w-max grid-flow-col grid-rows-7 gap-1">
+          {#each activityCells as cell}
+            <div
+              class={`h-3 w-3 rounded-sm border border-base-stroke-default ${activityClass(cell.level)}`}
+              title={`${cell.dateKey}: ${cell.count}`}
+              aria-label={`${cell.dateKey}: ${cell.count}`}
+            ></div>
+          {/each}
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -29,7 +29,7 @@
     { label: "AGC", value: "agc" },
     { label: "Other", value: "other" },
   ] as const;
-  const ACTIVITY_DAYS = 182;
+  const ACTIVITY_DAYS = 365;
 
   let cachedInput = loadLastInput();
   let currentInput: ClosedRange | null;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -116,6 +116,7 @@
       const json: Problem = await res.json();
 
       setTimeout(() => {
+        pickActivity = recordPickActivity();
         result = json;
         loading = false;
       }, 1050);
@@ -140,10 +141,6 @@
 
   const clickDialog = (result: boolean): void => {
     isDialogOpen = !isDialogOpen;
-  };
-
-  const markSolved = (): void => {
-    pickActivity = recordPickActivity();
   };
 
   const toggleContest = (contest: string): void => {
@@ -207,8 +204,7 @@
     const start = new Date(year, 0, 1);
     const end = new Date(year, 11, 31);
     const activityDays =
-      Math.floor((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000)) +
-      1;
+      Math.floor((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000)) + 1;
 
     return Array.from({ length: activityDays }, (_, index) => {
       const date = new Date(start);
@@ -381,14 +377,6 @@
                 >Difficulty: {Math.floor(result!.difficulty)}</Label
               >
             </Dialog>
-
-            <Button
-              size="tiny"
-              variant="success"
-              tone="ghost"
-              class="mt-2"
-              onclick={markSolved}>解いた</Button
-            >
           </div>
         </Message>
       </div>
@@ -408,10 +396,12 @@
       </div>
     {/if}
 
-    <div class="relative left-1/2 mt-4 flex w-screen -translate-x-1/2 flex-col items-center gap-2">
-      <Label class="!text-[1rem] !font-medium">Activity</Label>
+    <div
+      class="relative left-1/2 mt-10 flex w-screen -translate-x-1/2 flex-col items-center gap-3"
+    >
+      <Label class="!text-[1.25rem] !font-normal">Activity</Label>
       <div class="w-screen overflow-x-auto pb-1">
-        <div class="mx-auto flex w-max items-center gap-3">
+        <div class="mx-auto flex w-max items-center gap-8">
           <div class="grid grid-flow-col grid-rows-7 gap-1">
             {#each activityCells as cell}
               <div
@@ -425,7 +415,7 @@
             {#each activityYears as year}
               <button
                 type="button"
-                class={`rounded-sm px-1 text-left !text-[0.875rem] ${
+                class={`cursor-pointer rounded-sm px-1 text-left !text-[1rem] ${
                   selectedActivityYear === year
                     ? "text-base-foreground-default"
                     : "text-base-foreground-muted"

--- a/frontend/src/utils/cacher.ts
+++ b/frontend/src/utils/cacher.ts
@@ -7,6 +7,9 @@ export type CachedInput = {
 };
 
 const rangeKey: string = 'lastDiff';
+const activityKey: string = 'pickActivity';
+
+export type PickActivity = Record<string, number>;
 
 export const cacheInput = (input: CachedInput): void => {
   localStorage.setItem(rangeKey, JSON.stringify(input));
@@ -32,4 +35,41 @@ export const loadLastInput = (): CachedInput | null => {
     contest_from: parsed.contest_from ?? "",
     contest_to: parsed.contest_to ?? "",
   };
+};
+
+const getDateKey = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+};
+
+export const loadPickActivity = (): PickActivity => {
+  const data = localStorage.getItem(activityKey);
+
+  if (!data) {
+    return {};
+  }
+
+  const parsed = JSON.parse(data) as PickActivity;
+
+  return Object.fromEntries(
+    Object.entries(parsed).filter(
+      ([, count]) => Number.isInteger(count) && count > 0,
+    ),
+  );
+};
+
+export const recordPickActivity = (date = new Date()): PickActivity => {
+  const activity = loadPickActivity();
+  const dateKey = getDateKey(date);
+  const nextActivity = {
+    ...activity,
+    [dateKey]: (activity[dateKey] ?? 0) + 1,
+  };
+
+  localStorage.setItem(activityKey, JSON.stringify(nextActivity));
+
+  return nextActivity;
 };


### PR DESCRIPTION
## Summary

- Store local pick activity counts by date in `localStorage`.
- Increment activity when a pick succeeds.
- Add a GitHub contribution-style activity calendar for the selected year.
- Add selectable year labels next to the calendar.
- Center the calendar and allow horizontal scrolling when it exceeds the viewport width.

## Validation

- `./node_modules/.bin/svelte-check --tsconfig ./tsconfig.app.json` in `frontend`
- `bun run build` in `frontend`