### PR TITLE
Fix query input error handling

### DIFF
--- a/backend/src/utils/routing.rs
+++ b/backend/src/utils/routing.rs
@@ -15,7 +15,6 @@ use std::vec::Vec;
 use crate::utils::api::{Problem, ProblemModel};
 
 const MIN_DIFFICULTY: f64 = 0.0;
-const MAX_DIFFICULTY: f64 = 3854.0;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -78,24 +77,38 @@ fn parse_optional_f64(params: &HashMap<String, String>, key: &str) -> Result<Opt
     params
         .get(key)
         .map(|value| {
+            let value = value.trim();
+            if value.is_empty() {
+                return Ok(None);
+            }
+
             value
                 .parse::<f64>()
                 .ok()
                 .filter(|value| value.is_finite())
+                .map(Some)
                 .ok_or_else(|| format!("'{}' must be a number.", key))
         })
         .transpose()
+        .map(Option::flatten)
 }
 
 fn parse_optional_u32(params: &HashMap<String, String>, key: &str) -> Result<Option<u32>, String> {
     params
         .get(key)
         .map(|value| {
+            let value = value.trim();
+            if value.is_empty() {
+                return Ok(None);
+            }
+
             value
                 .parse::<u32>()
+                .map(Some)
                 .map_err(|_| format!("'{}' must be a positive integer.", key))
         })
         .transpose()
+        .map(Option::flatten)
 }
 
 fn log(now: DateTime<Local>, method: &str, path: &str, status: StatusCode) {
@@ -156,7 +169,7 @@ pub async fn router(
                 Err(message) => return Ok(bad_request(&message)),
             };
             let max: f64 = match parse_optional_f64(&params, "max") {
-                Ok(max) => max.unwrap_or(MAX_DIFFICULTY),
+                Ok(max) => max.unwrap_or(f64::INFINITY),
                 Err(message) => return Ok(bad_request(&message)),
             };
             let allows_unknown_difficulty =
@@ -189,10 +202,6 @@ pub async fn router(
 
             if min < MIN_DIFFICULTY {
                 return Ok(bad_request("'min' cannot be less than 0."));
-            }
-
-            if max > MAX_DIFFICULTY {
-                return Ok(bad_request("'max' cannot be greater than 3854."));
             }
 
             if contest_from

--- a/backend/tests/routing_test.rs
+++ b/backend/tests/routing_test.rs
@@ -16,6 +16,18 @@ fn build_test_state() -> Arc<AppState> {
         },
     );
     problem_models.insert(
+        "arc001_a".to_string(),
+        ProblemModel {
+            difficulty: Some(1100.0),
+        },
+    );
+    problem_models.insert(
+        "agc001_a".to_string(),
+        ProblemModel {
+            difficulty: Some(1200.0),
+        },
+    );
+    problem_models.insert(
         "abc212_a".to_string(),
         ProblemModel {
             difficulty: Some(900.0),
@@ -46,6 +58,16 @@ fn build_test_state() -> Arc<AppState> {
             id: "abc001_a".to_string(),
             contest_id: "abc001".to_string(),
             name: "A - Test Problem".to_string(),
+        },
+        Problem {
+            id: "arc001_a".to_string(),
+            contest_id: "arc001".to_string(),
+            name: "A - ARC Test Problem".to_string(),
+        },
+        Problem {
+            id: "agc001_a".to_string(),
+            contest_id: "agc001".to_string(),
+            name: "A - AGC Test Problem".to_string(),
         },
         Problem {
             id: "abc212_a".to_string(),
@@ -133,10 +155,18 @@ async fn test_negative_min_is_bad_request() {
 }
 
 #[tokio::test]
-async fn test_max_over_upper_limit_is_bad_request() {
+async fn test_max_over_previous_upper_limit_is_allowed() {
     let (status, body) = build_and_send(Method::GET, "/?min=0&max=3855").await;
-    assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert_eq!(body, "'max' cannot be greater than 3854.");
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        difficulty: f64,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+
+    assert!(problem.difficulty <= 3855.0);
 }
 
 #[tokio::test]
@@ -191,6 +221,92 @@ async fn test_contest_number_from() {
 
     assert_eq!(problem.id, "abc212_a");
     assert_eq!(problem.contest_id, "abc212");
+}
+
+#[tokio::test]
+async fn test_contest_number_to_without_from() {
+    let (status, body) = build_and_send(
+        Method::GET,
+        "/?min=0&max=1500&contest=abc,arc,agc&contest_to=1",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        id: String,
+        contest_id: String,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+
+    assert!(["abc001_a", "arc001_a", "agc001_a"].contains(&problem.id.as_str()));
+    assert!(["abc001", "arc001", "agc001"].contains(&problem.contest_id.as_str()));
+}
+
+#[tokio::test]
+async fn test_empty_contest_from_is_ignored() {
+    let (status, body) = build_and_send(
+        Method::GET,
+        "/?min=0&max=1500&contest=abc,arc,agc&contest_from=&contest_to=1",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        contest_id: String,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+
+    assert!(["abc001", "arc001", "agc001"].contains(&problem.contest_id.as_str()));
+}
+
+#[tokio::test]
+async fn test_agc_only_can_be_picked() {
+    let (status, body) = build_and_send(Method::GET, "/?min=0&max=1500&contest=agc").await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        contest_id: String,
+        difficulty: f64,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+
+    assert!(problem.contest_id.starts_with("agc"));
+    assert!(problem.difficulty <= 1500.0);
+}
+
+#[tokio::test]
+async fn test_agc_only_with_large_max_is_not_bad_request() {
+    let (status, body) = build_and_send(Method::GET, "/?min=0&max=999999&contest=agc").await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        contest_id: String,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+
+    assert!(problem.contest_id.starts_with("agc"));
+}
+
+#[tokio::test]
+async fn test_agc_only_without_matching_difficulty_is_not_found() {
+    let (status, body) = build_and_send(Method::GET, "/?min=1300&max=1400&contest=agc").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    #[derive(serde::Deserialize)]
+    struct ErrorResponse {
+        message: String,
+    }
+
+    let err: ErrorResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(err.message, "指定Diff範囲に該当する問題がありませんでした");
 }
 
 #[tokio::test]

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -36,8 +36,12 @@
   let min_diff = $state<number>(cachedInput ? cachedInput.min : MIN_DIFF);
   let max_diff = $state<number>(cachedInput ? cachedInput.max : MAX_DIFF);
   let selectedContests = $state<string[]>(cachedInput?.selectedContests ?? []);
-  let contest_from = $state<string>(cachedInput?.contest_from ?? "");
-  let contest_to = $state<string>(cachedInput?.contest_to ?? "");
+  let contest_from = $state<string | number | null | undefined>(
+    cachedInput?.contest_from ?? "",
+  );
+  let contest_to = $state<string | number | null | undefined>(
+    cachedInput?.contest_to ?? "",
+  );
 
   /*
    * バリデーションチェック
@@ -51,9 +55,10 @@
     isMinusMaxDiff: max_diff < 0,
   });
   let contestRoundError = $derived(
-    contest_from !== "" &&
-      contest_to !== "" &&
-      Number(contest_from) > Number(contest_to),
+    inputValueToString(contest_from) !== "" &&
+      inputValueToString(contest_to) !== "" &&
+      Number(inputValueToString(contest_from)) >
+        Number(inputValueToString(contest_to)),
   );
 
   let result = $state<Problem | null>(null); // 取得した問題
@@ -90,11 +95,13 @@
       if (selectedContests.length > 0) {
         params.set("contest", selectedContests.join(","));
       }
-      if (contest_from !== "") {
-        params.set("contest_from", contest_from);
+      const contestFromParam = inputValueToString(contest_from);
+      const contestToParam = inputValueToString(contest_to);
+      if (contestFromParam !== "") {
+        params.set("contest_from", contestFromParam);
       }
-      if (contest_to !== "") {
-        params.set("contest_to", contest_to);
+      if (contestToParam !== "") {
+        params.set("contest_to", contestToParam);
       }
 
       const API_CONTENT = `${API_URL}/?${params.toString()}`;
@@ -110,7 +117,7 @@
 
       // 正常に問題が返ってきた場合
       if (!res.ok) {
-        throw new Error(`HTTPエラー: ${res.status}`);
+        throw new Error("指定範囲内に該当する問題がありませんでした");
       }
 
       const json: Problem = await res.json();
@@ -158,8 +165,8 @@
       min: currentInput.min,
       max: currentInput.max,
       selectedContests,
-      contest_from,
-      contest_to,
+      contest_from: inputValueToString(contest_from),
+      contest_to: inputValueToString(contest_to),
     });
     sendQuery();
   };
@@ -235,6 +242,14 @@
     }
 
     return "bg-success";
+  }
+
+  function inputValueToString(value: string | number | null | undefined): string {
+    if (value === null || value === undefined) {
+      return "";
+    }
+
+    return String(value).trim();
   }
 </script>
 


### PR DESCRIPTION
## Summary

- Stop rejecting large `max` values with HTTP 400 so AGC/high-difficulty searches can return results or normal not-found responses.
- Treat empty query values such as `contest_from=` as omitted on the backend.
- Normalize contest round inputs on the frontend before building query parameters.
- Show the existing user-facing not-found message instead of `HTTPエラー: 400` for failed API responses.
- Add regression coverage for AGC-only picks, large max values, empty `contest_from`, and `contest_to`-only standard contest filtering.

## Root Cause

The previous query validation introduced a stale fixed upper bound for difficulty (`3854`), but the refreshed data contains higher difficulties. That made some valid AGC searches fail as bad requests. The frontend also only converted 404 responses into the existing user-facing message, so 400 responses leaked as `HTTPエラー: 400`.

## Validation

- `cargo test`
- `bunx svelte-check --tsconfig ./tsconfig.app.json`
- `bun run build`
- `rustfmt --edition 2021 --check backend/src/utils/routing.rs backend/tests/routing_test.rs`
- Manual local API checks for AGC-only, large max, `contest_to=1`, `contest_from=&contest_to=1`, and invalid range cases