### PR TITLE
Reset diff inputs to blank

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -33,8 +33,8 @@
   let cachedInput = loadLastInput();
   let currentInput: ClosedRange | null;
 
-  let min_diff = $state<number>(cachedInput ? cachedInput.min : MIN_DIFF);
-  let max_diff = $state<number>(cachedInput ? cachedInput.max : MAX_DIFF);
+  let min_diff = $state<number | "">(cachedInput ? cachedInput.min : MIN_DIFF);
+  let max_diff = $state<number | "">(cachedInput ? cachedInput.max : MAX_DIFF);
   let selectedContests = $state<string[]>(cachedInput?.selectedContests ?? []);
   let contest_from = $state<string | number | null | undefined>(
     cachedInput?.contest_from ?? "",
@@ -51,8 +51,8 @@
    */
   let errors = $derived({
     rangeError: !(currentInput = createValidRange(min_diff, max_diff)),
-    isMinusMinDiff: min_diff < 0,
-    isMinusMaxDiff: max_diff < 0,
+    isMinusMinDiff: min_diff !== "" && min_diff < 0,
+    isMinusMaxDiff: max_diff !== "" && max_diff < 0,
   });
   let contestRoundError = $derived(
     inputValueToString(contest_from) !== "" &&
@@ -87,10 +87,13 @@
 
     try {
       const API_URL = import.meta.env.VITE_API_URL;
-      const params = new URLSearchParams({
-        min: String(min_diff),
-        max: String(max_diff),
-      });
+      const params = new URLSearchParams();
+      if (min_diff !== "") {
+        params.set("min", String(min_diff));
+      }
+      if (max_diff !== "") {
+        params.set("max", String(max_diff));
+      }
 
       if (selectedContests.length > 0) {
         params.set("contest", selectedContests.join(","));
@@ -172,14 +175,14 @@
   };
 
   const setDefault = (): void => {
-    min_diff = MIN_DIFF;
-    max_diff = MAX_DIFF;
+    min_diff = "";
+    max_diff = "";
     selectedContests = ["abc"];
     contest_from = "212";
     contest_to = "";
     cacheInput({
-      min: MIN_DIFF,
-      max: MAX_DIFF,
+      min: "",
+      max: "",
       selectedContests: ["abc"],
       contest_from: "212",
       contest_to: "",

--- a/frontend/src/utils/cacher.ts
+++ b/frontend/src/utils/cacher.ts
@@ -1,6 +1,6 @@
 export type CachedInput = {
-  min: number;
-  max: number;
+  min: number | "";
+  max: number | "";
   selectedContests: string[];
   contest_from: string;
   contest_to: string;
@@ -24,7 +24,10 @@ export const loadLastInput = (): CachedInput | null => {
 
   const parsed = JSON.parse(data) as Partial<CachedInput>;
 
-  if (typeof parsed.min !== "number" || typeof parsed.max !== "number") {
+  if (
+    (typeof parsed.min !== "number" && parsed.min !== "") ||
+    (typeof parsed.max !== "number" && parsed.max !== "")
+  ) {
     return null;
   }
 

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -6,11 +6,11 @@ export interface Problem {
 };
 
 export type ClosedRange = {
-  min: number;
-  max: number;
+  min: number | "";
+  max: number | "";
 } & { readonly __brand: unique symbol }; 
 
 // for validation
-export const createValidRange = (min: number, max: number): ClosedRange | null => {
-  return min>max ? null : {min, max, __brand: Symbol('ClosedRange') as never};
+export const createValidRange = (min: number | "", max: number | ""): ClosedRange | null => {
+  return min !== "" && max !== "" && min>max ? null : {min, max, __brand: Symbol('ClosedRange') as never};
 }


### PR DESCRIPTION
## Summary

- Reset now clears both min and max difficulty inputs instead of restoring fixed defaults.
- Blank min/max values are omitted from the API query parameters.
- Cached input and range validation now support blank min/max values.

## Impact

Reset keeps the default contest and round behavior, but leaves the difficulty range open-ended. The backend default handling is used when min or max are omitted.

## Validation

- `bunx svelte-check --tsconfig ./tsconfig.app.json`
- `bun run build`
- `cargo test`