### PR TITLE
Improve responsive layout

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -280,7 +280,7 @@
       </p>
     {/if}
 
-    <div class="flex items-center gap-2">
+    <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_6rem] sm:items-center">
       <Input
         type="number"
         placeholder="最低Diffを入力してください。"
@@ -295,7 +295,7 @@
       />
       <Button
         onclick={handlePick}
-        class="shrink-0 w-24 h-12 flex justify-center items-center"
+        class="flex h-12 w-full items-center justify-center"
         disabled={loading ||
           errors.rangeError ||
           errors.isMinusMinDiff ||
@@ -313,13 +313,13 @@
     </div>
 
     <div
-      class="mt-3 flex items-center justify-between gap-2"
+      class="mt-3 flex flex-col items-stretch justify-between gap-3 sm:flex-row sm:items-center sm:gap-2"
       aria-label="Contest filters"
     >
-      <div class="flex flex-wrap gap-2">
+      <div class="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
         {#each CONTEST_OPTIONS as contest}
           <label
-            class="inline-flex items-center gap-2 rounded-md border border-base-stroke-default px-3 py-2 !text-[1rem] text-base-foreground-default"
+            class="inline-flex min-h-11 items-center gap-2 rounded-md border border-base-stroke-default px-3 py-2 !text-[1rem] text-base-foreground-default"
           >
             <input
               type="checkbox"
@@ -334,7 +334,7 @@
 
       <Button
         onclick={setDefault}
-        class="shrink-0 w-24 h-12 flex justify-center items-center"
+        class="flex h-12 w-full shrink-0 items-center justify-center sm:w-24"
         variant="danger"
         tone="ghost"
       >
@@ -342,7 +342,7 @@
       </Button>
     </div>
 
-    <div class="grid grid-cols-2 gap-2 mt-3">
+    <div class="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
       <Input
         type="number"
         min="1"
@@ -370,7 +370,7 @@
             <p class="text-base-foreground-default mb-1 text-sm">
               URL:
               <a
-                class="text-blue-600 underline"
+                class="break-all text-blue-600 underline"
                 href={`https://atcoder.jp/contests/${result.contest_id}/tasks/${result.id}`}
                 target="_blank"
               >
@@ -383,7 +383,7 @@
               size="tiny"
               variant="danger"
               tone="ghost"
-              class="mt-8"
+              class="mt-8 w-full sm:w-[13.5rem]"
               onclick={toggleDialog}>Show Difficulty</Button
             >
             <Dialog

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -258,7 +258,9 @@
 
 <div class="flex min-h-dvh flex-col">
   <main class="app-container flex w-full max-w-xl flex-col gap-2">
-    <h1 class="mb-6 text-4xl leading-tight sm:mb-8 sm:text-5xl">
+    <h1
+      class="mb-6 text-4xl leading-tight sm:mb-8 sm:self-center sm:whitespace-nowrap sm:text-[2.5rem] lg:text-5xl"
+    >
       AtCoder Random Picker
     </h1>
 
@@ -449,7 +451,7 @@
     </div>
   </main>
 
-  <footer class="mt-auto flex w-full shrink-0 justify-center px-4 py-4 md:mt-0">
+  <footer class="mt-auto flex w-full shrink-0 justify-center px-4 py-4 sm:mt-0">
     <a
       class="!text-[0.875rem] text-base-foreground-muted underline underline-offset-4 hover:text-base-foreground-default"
       href="https://github.com/Twil3akine/atcoder-random-picker/issues/new/choose"

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -257,7 +257,7 @@
 </script>
 
 <div class="flex min-h-dvh flex-col">
-  <main class="app-container flex w-full max-w-xl flex-1 flex-col gap-2">
+  <main class="app-container flex w-full max-w-xl flex-col gap-2">
     <h1 class="mb-6 text-4xl leading-tight sm:mb-8 sm:text-5xl">
       AtCoder Random Picker
     </h1>
@@ -449,7 +449,7 @@
     </div>
   </main>
 
-  <footer class="flex w-full shrink-0 justify-center px-4 py-4">
+  <footer class="mt-auto flex w-full shrink-0 justify-center px-4 py-4 md:mt-0">
     <a
       class="!text-[0.875rem] text-base-foreground-muted underline underline-offset-4 hover:text-base-foreground-default"
       href="https://github.com/Twil3akine/atcoder-random-picker/issues/new/choose"

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -256,9 +256,11 @@
   }
 </script>
 
-<div class="w-full h-full">
-  <div class="container flex flex-col max-w-xl w-full gap-2">
-    <h1 class="text-3xl mb-8">AtCoder Random Picker</h1>
+<div class="flex min-h-dvh flex-col">
+  <main class="app-container flex w-full max-w-xl flex-1 flex-col gap-2">
+    <h1 class="mb-6 text-4xl leading-tight sm:mb-8 sm:text-5xl">
+      AtCoder Random Picker
+    </h1>
 
     {#if errors.rangeError}
       <p class="text-destructive mb-2 text-sm">
@@ -414,12 +416,10 @@
       </div>
     {/if}
 
-    <div
-      class="relative left-1/2 mt-10 flex w-screen -translate-x-1/2 flex-col items-center gap-3"
-    >
+    <div class="mt-10 flex w-full flex-col items-center gap-3">
       <Label class="!text-[1.25rem] !font-normal">Activity</Label>
-      <div class="w-screen overflow-x-auto pb-1">
-        <div class="mx-auto flex w-max items-center gap-8">
+      <div class="activity-scroll w-full overflow-x-auto pb-2">
+        <div class="flex w-max min-w-full items-center justify-center gap-6 px-1 sm:gap-8">
           <div class="grid grid-flow-col grid-rows-7 gap-1">
             {#each activityCells as cell}
               <div
@@ -447,9 +447,9 @@
         </div>
       </div>
     </div>
-  </div>
+  </main>
 
-  <footer class="fixed bottom-4 left-0 flex w-full justify-center">
+  <footer class="flex w-full shrink-0 justify-center px-4 py-4">
     <a
       class="!text-[0.875rem] text-base-foreground-muted underline underline-offset-4 hover:text-base-foreground-default"
       href="https://github.com/Twil3akine/atcoder-random-picker/issues/new/choose"

--- a/frontend/src/components/Button.svelte
+++ b/frontend/src/components/Button.svelte
@@ -39,7 +39,7 @@
         },
         /** ボタンのサイズ */
         size: {
-          tiny: ['w-[13.5rem] py-2 min-h-7'],
+          tiny: ['min-h-9 px-3 py-2'],
           small: ['px-3 py-2 min-h-9'],
           medium: ['px-4 py-2.5 min-h-10'],
           large: ['px-8 py-3 min-h-11'],

--- a/frontend/src/components/Dialog.svelte
+++ b/frontend/src/components/Dialog.svelte
@@ -20,7 +20,7 @@
   import type { Snippet } from 'svelte';
 
   export const dialogVariants = cva(
-    'relative flex flex-col gap-6 p-6 bg-base-container-default border border-base-stroke-default border-secondary rounded-lg shadow-lg',
+    'relative flex max-h-[calc(100dvh-2rem)] max-w-[calc(100vw-2rem)] flex-col gap-6 overflow-y-auto p-6 bg-base-container-default border border-base-stroke-default border-secondary rounded-lg shadow-lg',
   );
 
   export type DialogVariants = VariantProps<typeof dialogVariants>;
@@ -101,7 +101,7 @@
 
 {#if open}
   <div class="fixed inset-0 bg-base-container-default/25 z-40 backdrop-blur-xs" bind:this={backgroundElement} transition:fade={{ duration: 105 }}></div>
-  <div class="fixed inset-0 z-50 size-fit m-auto">
+  <div class="fixed inset-4 z-50 m-auto flex items-center justify-center">
     <div class={dialogVariantsClass} transition:scale={{ start: 0.9, duration: 105 }}>
       {@render children()}
       {#if enableClose}

--- a/frontend/src/components/Message.svelte
+++ b/frontend/src/components/Message.svelte
@@ -81,7 +81,7 @@
 </script>
 
 <div class={messageVariantClass}>
-  <div class={messageIconVariantClass}>
+  <div class={`${messageIconVariantClass} shrink-0`}>
     {#if variant === "error"}
       <CircleAlert size="1.5rem" />
     {:else if variant === "warning"}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -88,13 +88,11 @@
 }
 
 html {
-  min-width: 20rem;
   background: var(--color-base-container-default);
   color: var(--color-base-foreground-default);
 }
 
 body {
-  min-width: 20rem;
   margin: 0;
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -87,22 +87,40 @@
   font-size: 103.5%;
 }
 
-h1 {
-  font-size: 3rem;
+html {
+  min-width: 20rem;
+  background: var(--color-base-container-default);
+  color: var(--color-base-foreground-default);
 }
 
-label {
-  font-size: 1.5rem;
+body {
+  min-width: 20rem;
+  margin: 0;
 }
 
-.container {
-  position: absolute;
-  top: 50vh;
-  left: 50vw;
-  transform: translate(-50%, -50%);
-  width: 70vw;
+#app {
+  min-height: 100dvh;
+}
+
+.app-container {
+  width: min(70vw, 36rem);
+  margin: auto;
+  padding: 2rem 0;
+}
+
+.activity-scroll {
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
 }
 
 details[open] summary span {
   transform: rotate(90deg);
+}
+
+@media (max-width: 47.999rem) {
+  .app-container {
+    width: 100%;
+    margin-block: 0;
+    padding: 1.5rem 1rem 2rem;
+  }
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -84,7 +84,6 @@
   font-family: "Ubuntu Sans Mono", "Noto Sans JP", "serif";
   text-decoration: none;
   list-style: none;
-  font-size: 103.5%;
 }
 
 html {
@@ -94,6 +93,7 @@ html {
 
 body {
   margin: 0;
+  font-size: 103.5%;
 }
 
 #app {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -115,7 +115,7 @@ details[open] summary span {
   transform: rotate(90deg);
 }
 
-@media (max-width: 47.999rem) {
+@media (max-width: 39.999rem) {
   .app-container {
     width: 100%;
     margin-block: 0;

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -12,7 +12,7 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
-    "noEmit": false,
+    "noEmit": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## 概要

既存のPCデザインを維持しながら、スマートフォン・タブレットで主要機能を操作しやすいレスポンシブレイアウトへ改善します。

## 変更内容

- 絶対配置による中央寄せを通常のページレイアウトへ変更
- 狭い画面でDiff入力、Pick、Reset、開催回入力を縦配置
- コンテスト選択をモバイルで2列表示し、タップ領域を拡大
- Activityを独立した横スクロール領域へ変更
- 固定フッターによる重なりを解消
- 結果URL、Difficultyダイアログ、ボタンの画面外はみ出しを防止
- Tailwindの文字サイズを上書きしていたグローバル指定を修正
- Vite設定用TypeScriptチェックをnoEmitで実行するよう修正

## 背景・影響

固定幅と絶対配置により、小さい画面で入力欄が過度に縮小し、Activityとフッターが重なる問題がありました。変更後は320px幅から横オーバーフローなしで利用できます。

## 確認

- `bun run check`
- `bun run build`
- 320px / 375px / 768px / 1440px幅で表示確認
- モバイルでReset操作を確認