### PR TITLE
Add responsive AdSense placements

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:3000
+VITE_ADSENSE_PREVIEW=true

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+VITE_API_URL=http://localhost:3000
+
+# Optional: leave both blank to disable ads in production.
+# Development shows a non-clickable preview when these are unset.
+VITE_ADSENSE_CLIENT=
+VITE_ADSENSE_SLOT=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,7 +1,9 @@
 VITE_API_URL=http://localhost:3000
 
 # Optional: leave blank to disable AdSense in production.
-# Development shows side rail / bottom anchor previews when this is unset.
+# Set to true only when checking the sample ad layout locally.
+VITE_ADSENSE_PREVIEW=false
+
 # In AdSense Auto ads settings, select:
 # - Side rail position: Left and right
 # - Anchor position: Bottom only

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,9 @@
 VITE_API_URL=http://localhost:3000
 
-# Optional: leave both blank to disable ads in production.
-# Development shows a non-clickable preview when these are unset.
+# Optional: leave blank to disable AdSense in production.
+# Development shows side rail / bottom anchor previews when this is unset.
+# In AdSense Auto ads settings, select:
+# - Side rail position: Left and right
+# - Anchor position: Bottom only
+# - Anchor ads on screens wider than 1000px: Off
 VITE_ADSENSE_CLIENT=
-VITE_ADSENSE_SLOT=

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Button from "./components/Button.svelte";
+  import AdSenseUnit from "./components/AdSenseUnit.svelte";
   import Dialog from "./components/Dialog.svelte";
   import Input from "./components/Input.svelte";
   import Label from "./components/Label.svelte";
@@ -449,6 +450,8 @@
         </div>
       </div>
     </div>
+
+    <AdSenseUnit />
   </main>
 
   <footer class="mt-auto flex w-full shrink-0 justify-center px-4 py-4 sm:mt-0">

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -451,8 +451,9 @@
       </div>
     </div>
 
-    <AdSenseUnit />
   </main>
+
+  <AdSenseUnit />
 
   <footer class="mt-auto flex w-full shrink-0 justify-center px-4 py-4 sm:mt-0">
     <a

--- a/frontend/src/components/AdSenseUnit.svelte
+++ b/frontend/src/components/AdSenseUnit.svelte
@@ -31,7 +31,9 @@
 
 {#if isConfigured || import.meta.env.DEV}
   <aside class="mt-8 w-full border-t border-base-stroke-default pt-4" aria-label="広告">
-    <p class="mb-2 text-center !text-xs text-base-foreground-muted">広告</p>
+    <p class="mb-2 text-center !text-xs text-base-foreground-muted">
+      {isConfigured ? "広告" : "広告プレビュー"}
+    </p>
 
     {#if isConfigured}
       <ins
@@ -43,9 +45,38 @@
       ></ins>
     {:else}
       <div
-        class="flex min-h-[5.625rem] w-full items-center justify-center rounded-md border border-dashed border-base-stroke-default bg-base-container-accent px-4 text-center !text-xs text-base-foreground-muted"
+        class="relative flex min-h-[10rem] w-full overflow-hidden rounded-xl border border-primary/20 bg-gradient-to-br from-primary/10 via-base-container-default to-success/10 p-5 shadow-sm sm:min-h-[7.5rem] sm:items-center sm:px-6"
       >
-        AdSense preview（環境変数を設定すると広告が表示されます）
+        <div
+          class="pointer-events-none absolute -right-10 -top-12 size-36 rounded-full bg-primary/10"
+        ></div>
+        <div
+          class="pointer-events-none absolute -bottom-12 right-16 size-28 rounded-full bg-success/10"
+        ></div>
+
+        <div
+          class="relative z-10 flex w-full flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div class="min-w-0">
+            <span
+              class="mb-2 inline-flex rounded-full bg-primary/10 px-2.5 py-1 !text-[0.6875rem] font-semibold tracking-wider text-primary"
+            >
+              SAMPLE AD
+            </span>
+            <p class="!text-lg font-semibold leading-snug text-base-foreground-default">
+              アルゴリズムを、毎日の習慣に。
+            </p>
+            <p class="mt-1 !text-xs leading-relaxed text-base-foreground-muted">
+              これは広告掲載位置を確認するための仮バナーです。
+            </p>
+          </div>
+
+          <span
+            class="inline-flex min-h-10 shrink-0 items-center justify-center self-start rounded-md bg-primary px-4 py-2 !text-xs font-medium text-primary-on-fill sm:self-center"
+          >
+            詳しく見る →
+          </span>
+        </div>
       </div>
     {/if}
   </aside>

--- a/frontend/src/components/AdSenseUnit.svelte
+++ b/frontend/src/components/AdSenseUnit.svelte
@@ -2,82 +2,102 @@
   import { onMount } from "svelte";
 
   const clientId = import.meta.env.VITE_ADSENSE_CLIENT?.trim();
-  const slotId = import.meta.env.VITE_ADSENSE_SLOT?.trim();
-  const isConfigured = Boolean(clientId && slotId);
+  const isConfigured = Boolean(clientId);
   const scriptId = "google-adsense-script";
 
+  let isPreviewOpen = $state(true);
+
   onMount(() => {
-    if (!isConfigured) {
+    if (!isConfigured || document.getElementById(scriptId)) {
       return;
     }
 
-    if (!document.getElementById(scriptId)) {
-      const script = document.createElement("script");
-      script.id = scriptId;
-      script.async = true;
-      script.crossOrigin = "anonymous";
-      script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${encodeURIComponent(clientId!)}`;
-      document.head.appendChild(script);
-    }
-
-    try {
-      window.adsbygoogle = window.adsbygoogle ?? [];
-      window.adsbygoogle.push({});
-    } catch (error) {
-      console.warn("AdSense ad could not be initialized.", error);
-    }
+    const script = document.createElement("script");
+    script.id = scriptId;
+    script.async = true;
+    script.crossOrigin = "anonymous";
+    script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${encodeURIComponent(clientId!)}`;
+    document.head.appendChild(script);
   });
 </script>
 
-{#if isConfigured || import.meta.env.DEV}
-  <aside class="mt-8 w-full border-t border-base-stroke-default pt-4" aria-label="広告">
-    <p class="mb-2 text-center !text-xs text-base-foreground-muted">
-      {isConfigured ? "広告" : "広告プレビュー"}
-    </p>
-
-    {#if isConfigured}
-      <ins
-        class="adsbygoogle block min-h-[5.625rem] w-full overflow-hidden"
-        data-ad-client={clientId}
-        data-ad-slot={slotId}
-        data-ad-format="auto"
-        data-full-width-responsive="true"
-      ></ins>
-    {:else}
-      <div
-        class="relative flex min-h-[10rem] w-full overflow-hidden rounded-xl border border-primary/20 bg-gradient-to-br from-primary/10 via-base-container-default to-success/10 p-5 shadow-sm sm:min-h-[7.5rem] sm:items-center sm:px-6"
+{#if import.meta.env.DEV && isPreviewOpen}
+  <!-- Tablet and mobile: bottom anchor preview -->
+  <div
+    class="pointer-events-none fixed inset-x-0 bottom-0 z-50 px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] xl:hidden"
+  >
+    <aside
+      class="pointer-events-auto relative mx-auto flex min-h-[5.5rem] w-full max-w-[22rem] items-center gap-3 overflow-visible rounded-xl border border-primary/20 bg-gradient-to-br from-primary/10 via-base-container-default to-success/10 px-4 py-3 shadow-lg"
+      aria-label="下部固定広告プレビュー"
+    >
+      <button
+        type="button"
+        class="absolute -top-3 right-2 flex size-7 cursor-pointer items-center justify-center rounded-full border border-base-stroke-default bg-base-container-default !text-sm leading-none text-base-foreground-muted shadow-sm"
+        aria-label="広告プレビューを閉じる"
+        onclick={() => (isPreviewOpen = false)}
       >
-        <div
-          class="pointer-events-none absolute -right-10 -top-12 size-36 rounded-full bg-primary/10"
-        ></div>
-        <div
-          class="pointer-events-none absolute -bottom-12 right-16 size-28 rounded-full bg-success/10"
-        ></div>
+        ×
+      </button>
 
-        <div
-          class="relative z-10 flex w-full flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+      <div class="min-w-0 flex-1">
+        <span class="!text-[0.625rem] font-semibold tracking-wider text-primary">
+          SAMPLE AD
+        </span>
+        <p class="truncate !text-sm font-semibold text-base-foreground-default">
+          毎日1問、アルゴリズム習慣
+        </p>
+        <p class="truncate !text-[0.6875rem] text-base-foreground-muted">
+          下部アンカー広告のプレビューです
+        </p>
+      </div>
+
+      <span
+        class="inline-flex min-h-9 shrink-0 items-center rounded-md bg-primary px-3 py-2 !text-[0.6875rem] font-medium text-primary-on-fill"
+      >
+        詳しく見る
+      </span>
+    </aside>
+  </div>
+
+  <!-- Wide desktop: left and right side rail previews -->
+  <div class="hidden xl:block" aria-label="左右レール広告プレビュー">
+    {#each ["left", "right"] as side}
+      <aside
+        class={`fixed top-1/2 z-30 flex h-[28rem] w-40 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-primary/20 bg-gradient-to-b from-primary/10 via-base-container-default to-success/10 p-4 shadow-md ${
+          side === "left" ? "left-6" : "right-6"
+        }`}
+        aria-label={`${side === "left" ? "左" : "右"}レール広告プレビュー`}
+      >
+        <button
+          type="button"
+          class="absolute right-2 top-2 flex size-7 cursor-pointer items-center justify-center rounded-full border border-base-stroke-default bg-base-container-default/90 !text-sm leading-none text-base-foreground-muted"
+          aria-label="広告プレビューを閉じる"
+          onclick={() => (isPreviewOpen = false)}
         >
-          <div class="min-w-0">
-            <span
-              class="mb-2 inline-flex rounded-full bg-primary/10 px-2.5 py-1 !text-[0.6875rem] font-semibold tracking-wider text-primary"
-            >
-              SAMPLE AD
-            </span>
-            <p class="!text-lg font-semibold leading-snug text-base-foreground-default">
-              アルゴリズムを、毎日の習慣に。
-            </p>
-            <p class="mt-1 !text-xs leading-relaxed text-base-foreground-muted">
-              これは広告掲載位置を確認するための仮バナーです。
-            </p>
-          </div>
+          ×
+        </button>
 
+        <span
+          class="mt-10 self-start rounded-full bg-primary/10 px-2 py-1 !text-[0.625rem] font-semibold tracking-wider text-primary"
+        >
+          SAMPLE AD
+        </span>
+        <p class="mt-5 !text-lg font-semibold leading-snug text-base-foreground-default">
+          毎日1問、<br />続ける力に。
+        </p>
+        <p class="mt-3 !text-xs leading-relaxed text-base-foreground-muted">
+          PCの左右に固定されるサイドレール広告のプレビューです。
+        </p>
+
+        <div class="mt-auto">
+          <div class="mb-5 h-24 rounded-full bg-primary/10"></div>
           <span
-            class="inline-flex min-h-10 shrink-0 items-center justify-center self-start rounded-md bg-primary px-4 py-2 !text-xs font-medium text-primary-on-fill sm:self-center"
+            class="flex min-h-10 items-center justify-center rounded-md bg-primary px-3 py-2 !text-xs font-medium text-primary-on-fill"
           >
-            詳しく見る →
+            詳しく見る
           </span>
         </div>
-      </div>
-    {/if}
-  </aside>
+      </aside>
+    {/each}
+  </div>
 {/if}

--- a/frontend/src/components/AdSenseUnit.svelte
+++ b/frontend/src/components/AdSenseUnit.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  const clientId = import.meta.env.VITE_ADSENSE_CLIENT?.trim();
+  const slotId = import.meta.env.VITE_ADSENSE_SLOT?.trim();
+  const isConfigured = Boolean(clientId && slotId);
+  const scriptId = "google-adsense-script";
+
+  onMount(() => {
+    if (!isConfigured) {
+      return;
+    }
+
+    if (!document.getElementById(scriptId)) {
+      const script = document.createElement("script");
+      script.id = scriptId;
+      script.async = true;
+      script.crossOrigin = "anonymous";
+      script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${encodeURIComponent(clientId!)}`;
+      document.head.appendChild(script);
+    }
+
+    try {
+      window.adsbygoogle = window.adsbygoogle ?? [];
+      window.adsbygoogle.push({});
+    } catch (error) {
+      console.warn("AdSense ad could not be initialized.", error);
+    }
+  });
+</script>
+
+{#if isConfigured || import.meta.env.DEV}
+  <aside class="mt-8 w-full border-t border-base-stroke-default pt-4" aria-label="広告">
+    <p class="mb-2 text-center !text-xs text-base-foreground-muted">広告</p>
+
+    {#if isConfigured}
+      <ins
+        class="adsbygoogle block min-h-[5.625rem] w-full overflow-hidden"
+        data-ad-client={clientId}
+        data-ad-slot={slotId}
+        data-ad-format="auto"
+        data-full-width-responsive="true"
+      ></ins>
+    {:else}
+      <div
+        class="flex min-h-[5.625rem] w-full items-center justify-center rounded-md border border-dashed border-base-stroke-default bg-base-container-accent px-4 text-center !text-xs text-base-foreground-muted"
+      >
+        AdSense preview（環境変数を設定すると広告が表示されます）
+      </div>
+    {/if}
+  </aside>
+{/if}

--- a/frontend/src/components/AdSenseUnit.svelte
+++ b/frontend/src/components/AdSenseUnit.svelte
@@ -3,9 +3,16 @@
 
   const clientId = import.meta.env.VITE_ADSENSE_CLIENT?.trim();
   const isConfigured = Boolean(clientId);
+  const isPreviewEnabled =
+    import.meta.env.DEV && import.meta.env.VITE_ADSENSE_PREVIEW === "true";
   const scriptId = "google-adsense-script";
 
-  let isPreviewOpen = $state(true);
+  const railSides = ["left", "right"] as const;
+  let isMobilePreviewOpen = $state(true);
+  let openRailPreviews = $state<Record<(typeof railSides)[number], boolean>>({
+    left: true,
+    right: true,
+  });
 
   onMount(() => {
     if (!isConfigured || document.getElementById(scriptId)) {
@@ -21,83 +28,89 @@
   });
 </script>
 
-{#if import.meta.env.DEV && isPreviewOpen}
+{#if isPreviewEnabled}
   <!-- Tablet and mobile: bottom anchor preview -->
-  <div
-    class="pointer-events-none fixed inset-x-0 bottom-0 z-50 px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] xl:hidden"
-  >
-    <aside
-      class="pointer-events-auto relative mx-auto flex min-h-[5.5rem] w-full max-w-[22rem] items-center gap-3 overflow-visible rounded-xl border border-primary/20 bg-gradient-to-br from-primary/10 via-base-container-default to-success/10 px-4 py-3 shadow-lg"
-      aria-label="下部固定広告プレビュー"
+  {#if isMobilePreviewOpen}
+    <div
+      class="pointer-events-none fixed inset-x-0 bottom-0 z-50 px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] xl:hidden"
     >
-      <button
-        type="button"
-        class="absolute -top-3 right-2 flex size-7 cursor-pointer items-center justify-center rounded-full border border-base-stroke-default bg-base-container-default !text-sm leading-none text-base-foreground-muted shadow-sm"
-        aria-label="広告プレビューを閉じる"
-        onclick={() => (isPreviewOpen = false)}
-      >
-        ×
-      </button>
-
-      <div class="min-w-0 flex-1">
-        <span class="!text-[0.625rem] font-semibold tracking-wider text-primary">
-          SAMPLE AD
-        </span>
-        <p class="truncate !text-sm font-semibold text-base-foreground-default">
-          毎日1問、アルゴリズム習慣
-        </p>
-        <p class="truncate !text-[0.6875rem] text-base-foreground-muted">
-          下部アンカー広告のプレビューです
-        </p>
-      </div>
-
-      <span
-        class="inline-flex min-h-9 shrink-0 items-center rounded-md bg-primary px-3 py-2 !text-[0.6875rem] font-medium text-primary-on-fill"
-      >
-        詳しく見る
-      </span>
-    </aside>
-  </div>
-
-  <!-- Wide desktop: left and right side rail previews -->
-  <div class="hidden xl:block" aria-label="左右レール広告プレビュー">
-    {#each ["left", "right"] as side}
       <aside
-        class={`fixed top-1/2 z-30 flex h-[28rem] w-40 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-primary/20 bg-gradient-to-b from-primary/10 via-base-container-default to-success/10 p-4 shadow-md ${
-          side === "left" ? "left-6" : "right-6"
-        }`}
-        aria-label={`${side === "left" ? "左" : "右"}レール広告プレビュー`}
+        class="pointer-events-auto relative mx-auto flex min-h-[5.5rem] w-full max-w-[22rem] items-center gap-3 overflow-visible rounded-xl border border-primary/20 bg-gradient-to-br from-primary/10 via-base-container-default to-success/10 px-4 py-3 shadow-lg"
+        aria-label="下部固定広告プレビュー"
       >
         <button
           type="button"
-          class="absolute right-2 top-2 flex size-7 cursor-pointer items-center justify-center rounded-full border border-base-stroke-default bg-base-container-default/90 !text-sm leading-none text-base-foreground-muted"
-          aria-label="広告プレビューを閉じる"
-          onclick={() => (isPreviewOpen = false)}
+          class="absolute -top-3 right-2 flex size-7 cursor-pointer items-center justify-center rounded-full border border-base-stroke-default bg-base-container-default !text-sm leading-none text-base-foreground-muted shadow-sm"
+          aria-label="下部広告プレビューを閉じる"
+          onclick={() => (isMobilePreviewOpen = false)}
         >
           ×
         </button>
 
-        <span
-          class="mt-10 self-start rounded-full bg-primary/10 px-2 py-1 !text-[0.625rem] font-semibold tracking-wider text-primary"
-        >
-          SAMPLE AD
-        </span>
-        <p class="mt-5 !text-lg font-semibold leading-snug text-base-foreground-default">
-          毎日1問、<br />続ける力に。
-        </p>
-        <p class="mt-3 !text-xs leading-relaxed text-base-foreground-muted">
-          PCの左右に固定されるサイドレール広告のプレビューです。
-        </p>
-
-        <div class="mt-auto">
-          <div class="mb-5 h-24 rounded-full bg-primary/10"></div>
-          <span
-            class="flex min-h-10 items-center justify-center rounded-md bg-primary px-3 py-2 !text-xs font-medium text-primary-on-fill"
-          >
-            詳しく見る
+        <div class="min-w-0 flex-1">
+          <span class="!text-[0.625rem] font-semibold tracking-wider text-primary">
+            SAMPLE AD
           </span>
+          <p class="truncate !text-sm font-semibold text-base-foreground-default">
+            毎日1問、アルゴリズム習慣
+          </p>
+          <p class="truncate !text-[0.6875rem] text-base-foreground-muted">
+            下部アンカー広告のプレビューです
+          </p>
         </div>
+
+        <span
+          class="inline-flex min-h-9 shrink-0 items-center rounded-md bg-primary px-3 py-2 !text-[0.6875rem] font-medium text-primary-on-fill"
+        >
+          詳しく見る
+        </span>
       </aside>
-    {/each}
-  </div>
+    </div>
+  {/if}
+
+  <!-- Wide desktop: left and right side rail previews -->
+  {#if openRailPreviews.left || openRailPreviews.right}
+    <div class="hidden xl:block" aria-label="左右レール広告プレビュー">
+      {#each railSides as side}
+        {#if openRailPreviews[side]}
+          <aside
+            class={`fixed top-1/2 z-30 flex h-[28rem] w-40 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-primary/20 bg-gradient-to-b from-primary/10 via-base-container-default to-success/10 p-4 shadow-md ${
+              side === "left" ? "left-6" : "right-6"
+            }`}
+            aria-label={`${side === "left" ? "左" : "右"}レール広告プレビュー`}
+          >
+            <button
+              type="button"
+              class="absolute right-2 top-2 flex size-7 cursor-pointer items-center justify-center rounded-full border border-base-stroke-default bg-base-container-default/90 !text-sm leading-none text-base-foreground-muted"
+              aria-label={`${side === "left" ? "左" : "右"}広告プレビューを閉じる`}
+              onclick={() => (openRailPreviews[side] = false)}
+            >
+              ×
+            </button>
+
+            <span
+              class="mt-10 self-start rounded-full bg-primary/10 px-2 py-1 !text-[0.625rem] font-semibold tracking-wider text-primary"
+            >
+              SAMPLE AD
+            </span>
+            <p class="mt-5 !text-lg font-semibold leading-snug text-base-foreground-default">
+              毎日1問、<br />続ける力に。
+            </p>
+            <p class="mt-3 !text-xs leading-relaxed text-base-foreground-muted">
+              PCの左右に固定されるサイドレール広告のプレビューです。
+            </p>
+
+            <div class="mt-auto">
+              <div class="mb-5 h-24 rounded-full bg-primary/10"></div>
+              <span
+                class="flex min-h-10 items-center justify-center rounded-md bg-primary px-3 py-2 !text-xs font-medium text-primary-on-fill"
+              >
+                詳しく見る
+              </span>
+            </div>
+          </aside>
+        {/if}
+      {/each}
+    </div>
+  {/if}
 {/if}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,2 +1,16 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+  readonly VITE_ADSENSE_CLIENT?: string;
+  readonly VITE_ADSENSE_SLOT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+interface Window {
+  adsbygoogle?: Record<string, unknown>[];
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -4,13 +4,8 @@
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_ADSENSE_CLIENT?: string;
-  readonly VITE_ADSENSE_SLOT?: string;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
-}
-
-interface Window {
-  adsbygoogle?: Record<string, unknown>[];
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -4,6 +4,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_ADSENSE_CLIENT?: string;
+  readonly VITE_ADSENSE_PREVIEW?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## 概要

AdSense Auto adsを読み込める設定を追加し、サイト本来の操作を妨げない広告配置を用意します。

> このPRは #59（`feat/responsive-layout`）をベースにした積み上げPRです。

## 変更内容

- `VITE_ADSENSE_CLIENT` によるAdSense設定
- 未設定の本番環境ではAdSenseを読み込まない安全な構成
- 開発環境で広告審査前にも配置を確認できる仮広告プレビュー
- ワイドPCでは本文外側の左右サイドレール表示
- スマートフォン・タブレットでは閉じられる下部アンカー表示
- 広告プレビューによるページ全体の横オーバーフローを防止
- `.env.example` にAuto adsの推奨設定を記載

## 背景・影響

メイン操作付近のインページ広告は誤クリックや操作阻害につながるため、PCでは左右の余白、狭い画面ではGoogle AdSenseのAnchor形式に近い下部固定配置を採用しました。

実際の広告表示はAdSense Auto adsの設定に従います。管理画面では以下を想定しています。

- Side rail: Left and right
- Anchor: Bottom only
- Anchor ads on screens wider than 1000px: Off

## 確認

- `bun run check`
- `bun run build`
- 375px幅で下部アンカー、閉じる操作、横オーバーフローなしを確認
- 1280px幅で左右レールと本文の非重複、横オーバーフローなしを確認