### PR TITLE
Add persistent pick history MVP

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@
   import Input from "./components/Input.svelte";
   import Label from "./components/Label.svelte";
   import Message from "./components/Message.svelte";
+  import PickHistory from "./components/PickHistory.svelte";
 
   import { Loader } from "@lucide/svelte";
   import {
@@ -16,8 +17,13 @@
     cacheInput,
     loadLastInput,
     loadPickActivity,
+    loadPickHistory,
     recordPickActivity,
+    recordPickHistory,
+    removePickHistoryEntry,
+    clearPickHistory,
     type PickActivity,
+    type PickHistoryEntry,
   } from "./utils/cacher";
 
   // ============================================================
@@ -66,6 +72,7 @@
   let errorMessage = $state<string | null>(null); // 取得できなかった場合に入るエラー
   let loading = $state<boolean>(false); // 問題を取得中か否か
   let pickActivity = $state<PickActivity>(loadPickActivity());
+  let pickHistory = $state<PickHistoryEntry[]>(loadPickHistory());
   let selectedActivityYear = $state<number>(new Date().getFullYear());
   let activityYears = $derived(buildActivityYears(pickActivity));
   let activityCells = $derived(
@@ -128,6 +135,7 @@
 
       setTimeout(() => {
         pickActivity = recordPickActivity();
+        pickHistory = recordPickHistory(json);
         result = json;
         loading = false;
       }, 1050);
@@ -188,6 +196,14 @@
       contest_from: "212",
       contest_to: "",
     });
+  };
+
+  const removeHistoryEntry = (entryId: string): void => {
+    pickHistory = removePickHistoryEntry(entryId);
+  };
+
+  const removeAllHistory = (): void => {
+    pickHistory = clearPickHistory();
   };
 
   function getDateKey(date: Date): string {
@@ -397,7 +413,9 @@
               onClick={(result) => clickDialog(result)}
             >
               <Label class="!text-lg !font-semibold"
-                >Difficulty: {Math.floor(result!.difficulty)}</Label
+                >Difficulty: {result.difficulty === null
+                  ? "Unknown"
+                  : Math.floor(result.difficulty)}</Label
               >
             </Dialog>
           </div>
@@ -418,6 +436,12 @@
         </Message>
       </div>
     {/if}
+
+    <PickHistory
+      history={pickHistory}
+      onRemove={removeHistoryEntry}
+      onClear={removeAllHistory}
+    />
 
     <div class="mt-10 flex w-full flex-col items-center gap-3">
       <Label class="!text-[1.25rem] !font-normal">Activity</Label>

--- a/frontend/src/components/PickHistory.svelte
+++ b/frontend/src/components/PickHistory.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import type { PickHistoryEntry } from "../utils/cacher";
+
+  type Props = {
+    history: PickHistoryEntry[];
+    onRemove: (entryId: string) => void;
+    onClear: () => void;
+  };
+
+  let { history, onRemove, onClear }: Props = $props();
+
+  const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const formatPickedAt = (pickedAt: string): string =>
+    dateFormatter.format(new Date(pickedAt));
+
+  const clearHistory = (): void => {
+    if (window.confirm("選出履歴をすべて削除しますか？")) {
+      onClear();
+    }
+  };
+</script>
+
+<section class="mt-8 w-full" aria-labelledby="pick-history-heading">
+  <details class="rounded-lg border border-base-stroke-default bg-base-container-default">
+    <summary
+      class="flex min-h-12 cursor-pointer items-center justify-between gap-3 px-4 py-3"
+    >
+      <span id="pick-history-heading" class="!text-[1rem] font-medium">
+        Pick History
+      </span>
+      <span class="flex items-center gap-2 !text-sm text-base-foreground-muted">
+        {history.length} / 50
+        <span class="details-chevron" aria-hidden="true">›</span>
+      </span>
+    </summary>
+
+    <div class="border-t border-base-stroke-default px-3 py-3 sm:px-4">
+      {#if history.length === 0}
+        <p class="py-5 text-center !text-sm text-base-foreground-muted">
+          選出した問題がここに表示されます。
+        </p>
+      {:else}
+        <div class="mb-3 flex justify-end">
+          <button
+            type="button"
+            class="min-h-10 cursor-pointer rounded-md px-3 py-2 !text-sm text-destructive hover:bg-destructive-on-fill"
+            onclick={clearHistory}
+          >
+            すべて削除
+          </button>
+        </div>
+
+        <ol class="max-h-80 space-y-2 overflow-y-auto pr-1">
+          {#each history as entry (entry.entryId)}
+            <li
+              class="flex items-start gap-3 rounded-md border border-base-stroke-default p-3"
+            >
+              <div class="min-w-0 flex-1">
+                <a
+                  class="block truncate !text-sm font-medium text-primary underline-offset-4 hover:underline"
+                  href={`https://atcoder.jp/contests/${entry.contest_id}/tasks/${entry.id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {entry.name}
+                </a>
+                <p class="mt-1 !text-xs text-base-foreground-muted">
+                  {entry.contest_id.toUpperCase()} · Diff {entry.difficulty === null
+                    ? "不明"
+                    : Math.floor(entry.difficulty)} ·
+                  {formatPickedAt(entry.pickedAt)}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                class="flex min-h-10 shrink-0 cursor-pointer items-center rounded-md px-2 !text-xs text-base-foreground-muted hover:bg-base-container-muted hover:text-base-foreground-default"
+                aria-label={`${entry.name}を履歴から削除`}
+                onclick={() => onRemove(entry.entryId)}
+              >
+                削除
+              </button>
+            </li>
+          {/each}
+        </ol>
+      {/if}
+    </div>
+  </details>
+</section>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -111,7 +111,12 @@ body {
   scrollbar-width: thin;
 }
 
-details[open] summary span {
+.details-chevron {
+  display: inline-block;
+  transition: transform 150ms ease;
+}
+
+details[open] .details-chevron {
   transform: rotate(90deg);
 }
 

--- a/frontend/src/utils/cacher.ts
+++ b/frontend/src/utils/cacher.ts
@@ -1,3 +1,5 @@
+import type { Problem } from "./types";
+
 export type CachedInput = {
   min: number | "";
   max: number | "";
@@ -8,8 +10,14 @@ export type CachedInput = {
 
 const rangeKey: string = 'lastDiff';
 const activityKey: string = 'pickActivity';
+const historyKey: string = "pickHistory";
+const maxHistoryEntries = 50;
 
 export type PickActivity = Record<string, number>;
+export type PickHistoryEntry = Problem & {
+  entryId: string;
+  pickedAt: string;
+};
 
 export const cacheInput = (input: CachedInput): void => {
   localStorage.setItem(rangeKey, JSON.stringify(input));
@@ -75,4 +83,79 @@ export const recordPickActivity = (date = new Date()): PickActivity => {
   localStorage.setItem(activityKey, JSON.stringify(nextActivity));
 
   return nextActivity;
+};
+
+const isPickHistoryEntry = (value: unknown): value is PickHistoryEntry => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const entry = value as Partial<PickHistoryEntry>;
+
+  return (
+    typeof entry.entryId === "string" &&
+    typeof entry.pickedAt === "string" &&
+    !Number.isNaN(Date.parse(entry.pickedAt)) &&
+    typeof entry.id === "string" &&
+    typeof entry.contest_id === "string" &&
+    typeof entry.name === "string" &&
+    (entry.difficulty === null ||
+      (typeof entry.difficulty === "number" &&
+        Number.isFinite(entry.difficulty)))
+  );
+};
+
+export const loadPickHistory = (): PickHistoryEntry[] => {
+  const data = localStorage.getItem(historyKey);
+
+  if (!data) {
+    return [];
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(data);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(isPickHistoryEntry).slice(0, maxHistoryEntries);
+  } catch {
+    return [];
+  }
+};
+
+export const recordPickHistory = (
+  problem: Problem,
+  date = new Date(),
+): PickHistoryEntry[] => {
+  const entry: PickHistoryEntry = {
+    ...problem,
+    entryId: `${date.getTime()}-${Math.random().toString(36).slice(2)}`,
+    pickedAt: date.toISOString(),
+  };
+  const nextHistory = [entry, ...loadPickHistory()].slice(
+    0,
+    maxHistoryEntries,
+  );
+
+  localStorage.setItem(historyKey, JSON.stringify(nextHistory));
+
+  return nextHistory;
+};
+
+export const removePickHistoryEntry = (entryId: string): PickHistoryEntry[] => {
+  const nextHistory = loadPickHistory().filter(
+    (entry) => entry.entryId !== entryId,
+  );
+
+  localStorage.setItem(historyKey, JSON.stringify(nextHistory));
+
+  return nextHistory;
+};
+
+export const clearPickHistory = (): PickHistoryEntry[] => {
+  localStorage.removeItem(historyKey);
+
+  return [];
 };

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -2,7 +2,7 @@ export interface Problem {
 	id: string;
 	contest_id: string;
 	name: string;
-	difficulty: number;
+	difficulty: number | null;
 };
 
 export type ClosedRange = {


### PR DESCRIPTION
## 概要

ランダム選出した問題をブラウザに保存し、後から確認できる選出履歴のMVPを追加します。

## 変更内容

- 正常に選出された問題を最新順で最大50件保存
- 問題名、コンテスト、Difficulty、選出日時を履歴に表示
- 履歴からAtCoderの問題ページを開けるリンクを追加
- 履歴の個別削除・全削除に対応
- 不正な保存データやDifficulty不明の問題を安全に処理
- 折りたたみ式かつレスポンシブな履歴UIを追加

## 目的・影響

現在のActivityでは選出回数のみを記録しており、どの問題を選んだか確認できませんでした。本変更により、ページを再読み込みした後も直近の問題へ戻れるようになります。保存先は既存機能と同じブラウザの`localStorage`で、バックエンド変更はありません。

## 動作確認

- `bun run check`
- `bun run build`
- `cargo test`（26 tests passed）
- 問題選出後の履歴追加
- 再読み込み後の履歴保持
- 個別削除
- 390px幅で横スクロールが発生しないことを確認