### PR TITLE
Add history-based problem exclusion

### DIFF
--- a/backend/src/utils/routing.rs
+++ b/backend/src/utils/routing.rs
@@ -170,7 +170,27 @@ fn with_cors_headers(mut res: Response<Body>) -> Response<Body> {
     res
 }
 
-fn standard_contest_number(contest_id: &str) -> Option<u32> {
+fn standard_contest_id(problem_id: &str) -> Option<&str> {
+    let (contest_id, _) = problem_id.rsplit_once('_')?;
+
+    for prefix in ["abc", "arc", "agc"] {
+        if let Some(number) = contest_id.strip_prefix(prefix) {
+            if number.parse::<u32>().is_ok() {
+                return Some(contest_id);
+            }
+        }
+    }
+
+    None
+}
+
+fn canonical_contest_id<'a>(problem_id: &'a str, contest_id: &'a str) -> &'a str {
+    standard_contest_id(problem_id).unwrap_or(contest_id)
+}
+
+fn standard_contest_number(problem_id: &str) -> Option<u32> {
+    let contest_id = standard_contest_id(problem_id)?;
+
     for prefix in ["abc", "arc", "agc"] {
         if let Some(number) = contest_id.strip_prefix(prefix) {
             return number.parse().ok();
@@ -254,23 +274,25 @@ pub async fn router(
                 .problems
                 .iter()
                 .filter(|p| {
+                    let contest_id = canonical_contest_id(&p.id, &p.contest_id);
+
                     if contest_filters.is_empty() {
                         return true;
                     }
                     contest_filters.iter().any(|filter| match filter {
-                        Contest::ABC => p.contest_id.starts_with("abc"),
-                        Contest::ARC => p.contest_id.starts_with("arc"),
-                        Contest::AGC => p.contest_id.starts_with("agc"),
+                        Contest::ABC => contest_id.starts_with("abc"),
+                        Contest::ARC => contest_id.starts_with("arc"),
+                        Contest::AGC => contest_id.starts_with("agc"),
                         Contest::Other => {
-                            !p.contest_id.starts_with("abc")
-                                && !p.contest_id.starts_with("arc")
-                                && !p.contest_id.starts_with("agc")
+                            !contest_id.starts_with("abc")
+                                && !contest_id.starts_with("arc")
+                                && !contest_id.starts_with("agc")
                         }
-                        Contest::Prefix(s) => p.contest_id.starts_with(s),
+                        Contest::Prefix(s) => contest_id.starts_with(s),
                     })
                 })
                 .filter(|p| {
-                    let Some(number) = standard_contest_number(&p.contest_id) else {
+                    let Some(number) = standard_contest_number(&p.id) else {
                         return contest_from.is_none() && contest_to.is_none();
                     };
 
@@ -284,13 +306,13 @@ pub async fn router(
                         .and_then(|m| match m.difficulty {
                             Some(diff) if min <= diff && diff <= max => Some(ProblemResponse {
                                 id: p.id.clone(),
-                                contest_id: p.contest_id.clone(),
+                                contest_id: canonical_contest_id(&p.id, &p.contest_id).to_string(),
                                 name: p.name.clone(),
                                 difficulty: Some(diff),
                             }),
                             None if allows_unknown_difficulty => Some(ProblemResponse {
                                 id: p.id.clone(),
-                                contest_id: p.contest_id.clone(),
+                                contest_id: canonical_contest_id(&p.id, &p.contest_id).to_string(),
                                 name: p.name.clone(),
                                 difficulty: None,
                             }),

--- a/backend/src/utils/routing.rs
+++ b/backend/src/utils/routing.rs
@@ -3,7 +3,7 @@ use core::prelude::v1::derive;
 use hyper::{header, Body, Request, Response, StatusCode};
 use rand::seq::IteratorRandom;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::{From, Infallible};
 use std::iter::Iterator;
 use std::option::Option::None;
@@ -15,6 +15,7 @@ use std::vec::Vec;
 use crate::utils::api::{Problem, ProblemModel};
 
 const MIN_DIFFICULTY: f64 = 0.0;
+const MAX_EXCLUDED_PROBLEMS: usize = 20;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -111,6 +112,38 @@ fn parse_optional_u32(params: &HashMap<String, String>, key: &str) -> Result<Opt
         .map(Option::flatten)
 }
 
+fn parse_excluded_problem_ids(params: &HashMap<String, String>) -> Result<HashSet<String>, String> {
+    let excluded = params
+        .get("exclude")
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(ToString::to_string)
+                .collect::<HashSet<String>>()
+        })
+        .unwrap_or_default();
+
+    if excluded.len() > MAX_EXCLUDED_PROBLEMS {
+        return Err(format!(
+            "'exclude' cannot contain more than {} problem IDs.",
+            MAX_EXCLUDED_PROBLEMS
+        ));
+    }
+
+    if excluded.iter().any(|id| {
+        id.len() > 100
+            || !id.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+            })
+    }) {
+        return Err("'exclude' contains an invalid problem ID.".to_string());
+    }
+
+    Ok(excluded)
+}
+
 fn log(now: DateTime<Local>, method: &str, path: &str, status: StatusCode) {
     println!(
         "[{}] {} {} -> {}",
@@ -195,6 +228,10 @@ pub async fn router(
                 Ok(contest_to) => contest_to,
                 Err(message) => return Ok(bad_request(&message)),
             };
+            let excluded_problem_ids = match parse_excluded_problem_ids(&params) {
+                Ok(excluded) => excluded,
+                Err(message) => return Ok(bad_request(&message)),
+            };
 
             if min > max {
                 return Ok(bad_request("'min' cannot be greater than 'max'."));
@@ -213,9 +250,7 @@ pub async fn router(
                 ));
             }
 
-            let mut rng = rand::thread_rng();
-
-            let selected = state
+            let candidates = state
                 .problems
                 .iter()
                 .filter(|p| {
@@ -262,6 +297,13 @@ pub async fn router(
                             _ => None,
                         })
                 })
+                .collect::<Vec<ProblemResponse>>();
+
+            let had_candidates_before_exclusion = !candidates.is_empty();
+            let mut rng = rand::thread_rng();
+            let selected = candidates
+                .into_iter()
+                .filter(|problem| !excluded_problem_ids.contains(&problem.id))
                 .choose(&mut rng);
 
             match selected {
@@ -270,8 +312,15 @@ pub async fn router(
                     Ok(with_cors_headers(Response::new(Body::from(body))))
                 }
                 None => {
+                    let message = if had_candidates_before_exclusion
+                        && !excluded_problem_ids.is_empty()
+                    {
+                        "履歴内の問題を除外すると、条件に一致する問題がありません。除外をOFFにするか、履歴を削除してください"
+                    } else {
+                        "指定Diff範囲に該当する問題がありませんでした"
+                    };
                     let error_body = serde_json::to_string(&ErrorResponse {
-                        message: "指定Diff範囲に該当する問題がありませんでした".to_string(),
+                        message: message.to_string(),
                     })
                     .unwrap();
 

--- a/backend/tests/routing_test.rs
+++ b/backend/tests/routing_test.rs
@@ -34,6 +34,12 @@ fn build_test_state() -> Arc<AppState> {
         },
     );
     problem_models.insert(
+        "abc212_b".to_string(),
+        ProblemModel {
+            difficulty: Some(925.0),
+        },
+    );
+    problem_models.insert(
         "abc213_a".to_string(),
         ProblemModel {
             difficulty: Some(850.0),
@@ -73,6 +79,11 @@ fn build_test_state() -> Arc<AppState> {
             id: "abc212_a".to_string(),
             contest_id: "abc212".to_string(),
             name: "A - Alloy".to_string(),
+        },
+        Problem {
+            id: "abc212_b".to_string(),
+            contest_id: "adt_all_20260615_2".to_string(),
+            name: "B - Weak Password".to_string(),
         },
         Problem {
             id: "abc213_a".to_string(),
@@ -144,7 +155,7 @@ async fn test_not_found_problem() {
 async fn test_excluded_problem_is_not_selected() {
     let (status, body) = build_and_send(
         Method::GET,
-        "/?min=800&max=1000&contest=abc&contest_from=212&contest_to=213&exclude=abc212_a",
+        "/?min=800&max=900&contest=abc&contest_from=212&contest_to=213&exclude=abc212_a",
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -162,7 +173,7 @@ async fn test_excluded_problem_is_not_selected() {
 async fn test_all_matching_problems_excluded_returns_specific_message() {
     let (status, body) = build_and_send(
         Method::GET,
-        "/?min=800&max=1000&contest=abc&contest_from=212&contest_to=213&exclude=abc212_a,abc213_a",
+        "/?min=800&max=900&contest=abc&contest_from=212&contest_to=213&exclude=abc212_a,abc213_a",
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
@@ -291,7 +302,7 @@ async fn test_random_range() {
 async fn test_contest_number_from() {
     let (status, body) = build_and_send(
         Method::GET,
-        "/?min=0&max=1500&contest=abc&contest_from=212&contest_to=212",
+        "/?min=900&max=900&contest=abc&contest_from=212&contest_to=212",
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -305,6 +316,27 @@ async fn test_contest_number_from() {
     let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
 
     assert_eq!(problem.id, "abc212_a");
+    assert_eq!(problem.contest_id, "abc212");
+}
+
+#[tokio::test]
+async fn test_reused_problem_uses_its_canonical_standard_contest() {
+    let (status, body) = build_and_send(
+        Method::GET,
+        "/?min=925&max=925&contest=abc&contest_from=212&contest_to=212",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        id: String,
+        contest_id: String,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(problem.id, "abc212_b");
     assert_eq!(problem.contest_id, "abc212");
 }
 
@@ -412,7 +444,7 @@ async fn test_multiple_contests_and_round_range_are_combined() {
 
     let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
 
-    assert!(["abc212_a", "arc212_a"].contains(&problem.id.as_str()));
+    assert!(["abc212_a", "abc212_b", "arc212_a"].contains(&problem.id.as_str()));
     assert!(["abc212", "arc212"].contains(&problem.contest_id.as_str()));
     assert!(800.0 <= problem.difficulty && problem.difficulty <= 1000.0);
 }
@@ -421,7 +453,7 @@ async fn test_multiple_contests_and_round_range_are_combined() {
 async fn test_multiple_contests_with_difficulty_range_narrows_candidates() {
     let (status, body) = build_and_send(
         Method::GET,
-        "/?min=925&max=975&contest=abc,arc&contest_from=212&contest_to=212",
+        "/?min=950&max=975&contest=abc,arc&contest_from=212&contest_to=212",
     )
     .await;
     assert_eq!(status, StatusCode::OK);

--- a/backend/tests/routing_test.rs
+++ b/backend/tests/routing_test.rs
@@ -141,6 +141,91 @@ async fn test_not_found_problem() {
 }
 
 #[tokio::test]
+async fn test_excluded_problem_is_not_selected() {
+    let (status, body) = build_and_send(
+        Method::GET,
+        "/?min=800&max=1000&contest=abc&contest_from=212&contest_to=213&exclude=abc212_a",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        id: String,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(problem.id, "abc213_a");
+}
+
+#[tokio::test]
+async fn test_all_matching_problems_excluded_returns_specific_message() {
+    let (status, body) = build_and_send(
+        Method::GET,
+        "/?min=800&max=1000&contest=abc&contest_from=212&contest_to=213&exclude=abc212_a,abc213_a",
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    #[derive(serde::Deserialize)]
+    struct ErrorResponse {
+        message: String,
+    }
+
+    let error: ErrorResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        error.message,
+        "履歴内の問題を除外すると、条件に一致する問題がありません。除外をOFFにするか、履歴を削除してください"
+    );
+}
+
+#[tokio::test]
+async fn test_empty_exclude_is_ignored() {
+    let (status, _) = build_and_send(Method::GET, "/?min=900&max=900&exclude=").await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_duplicate_excluded_problem_ids_count_once() {
+    let excluded = std::iter::repeat("abc212_a")
+        .take(21)
+        .collect::<Vec<_>>()
+        .join(",");
+    let path = format!("/?min=850&max=850&exclude={excluded}");
+    let (status, body) = build_and_send(Method::GET, &path).await;
+    assert_eq!(status, StatusCode::OK);
+
+    #[derive(serde::Deserialize)]
+    struct ProblemResponse {
+        id: String,
+    }
+
+    let problem: ProblemResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(problem.id, "abc213_a");
+}
+
+#[tokio::test]
+async fn test_more_than_twenty_excluded_problem_ids_is_bad_request() {
+    let excluded = (0..21)
+        .map(|index| format!("abc{index:03}_a"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let path = format!("/?exclude={excluded}");
+    let (status, body) = build_and_send(Method::GET, &path).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, "'exclude' cannot contain more than 20 problem IDs.");
+}
+
+#[tokio::test]
+async fn test_invalid_excluded_problem_id_is_bad_request() {
+    let (status, body) = build_and_send(Method::GET, "/?exclude=abc212%2Fa").await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, "'exclude' contains an invalid problem ID.");
+}
+
+#[tokio::test]
 async fn test_min_greater_than_max() {
     let (status, body) = build_and_send(Method::GET, "/?min=1500&max=500").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
+    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
+    "test": "bun test"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.1.0",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -18,10 +18,12 @@
     loadLastInput,
     loadPickActivity,
     loadPickHistory,
+    loadHistoryExclusionEnabled,
     recordPickActivity,
     recordPickHistory,
     removePickHistoryEntry,
     clearPickHistory,
+    saveHistoryExclusionEnabled,
     type PickActivity,
     type PickHistoryEntry,
   } from "./utils/cacher";
@@ -73,6 +75,12 @@
   let loading = $state<boolean>(false); // 問題を取得中か否か
   let pickActivity = $state<PickActivity>(loadPickActivity());
   let pickHistory = $state<PickHistoryEntry[]>(loadPickHistory());
+  let historyExclusionEnabled = $state<boolean>(
+    loadHistoryExclusionEnabled(),
+  );
+  let excludedHistoryIds = $derived(
+    Array.from(new Set(pickHistory.map((entry) => entry.id))),
+  );
   let selectedActivityYear = $state<number>(new Date().getFullYear());
   let activityYears = $derived(buildActivityYears(pickActivity));
   let activityCells = $derived(
@@ -113,6 +121,9 @@
       }
       if (contestToParam !== "") {
         params.set("contest_to", contestToParam);
+      }
+      if (historyExclusionEnabled && excludedHistoryIds.length > 0) {
+        params.set("exclude", excludedHistoryIds.join(","));
       }
 
       const API_CONTENT = `${API_URL}/?${params.toString()}`;
@@ -204,6 +215,10 @@
 
   const removeAllHistory = (): void => {
     pickHistory = clearPickHistory();
+  };
+
+  const updateHistoryExclusion = (enabled: boolean): void => {
+    historyExclusionEnabled = saveHistoryExclusionEnabled(enabled);
   };
 
   function getDateKey(date: Date): string {
@@ -375,6 +390,24 @@
         bind:value={contest_to}
       />
     </div>
+
+    <label
+      class="mt-3 flex min-h-11 cursor-pointer items-center gap-3 rounded-md border border-base-stroke-default px-3 py-2"
+    >
+      <input
+        type="checkbox"
+        class="size-4 shrink-0 accent-primary"
+        checked={historyExclusionEnabled}
+        onchange={(event) =>
+          updateHistoryExclusion(event.currentTarget.checked)}
+      />
+      <span class="!text-sm text-base-foreground-default">
+        履歴内の問題を除外
+      </span>
+      <span class="ml-auto shrink-0 !text-xs text-base-foreground-muted">
+        {excludedHistoryIds.length}件
+      </span>
+    </label>
 
     {#if !loading && result !== null}
       <div class="mt-4">

--- a/frontend/src/components/PickHistory.svelte
+++ b/frontend/src/components/PickHistory.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import type { PickHistoryEntry } from "../utils/cacher";
+  import {
+    MAX_PICK_HISTORY_ENTRIES,
+    type PickHistoryEntry,
+  } from "../utils/cacher";
 
   type Props = {
     history: PickHistoryEntry[];
@@ -35,7 +38,7 @@
         Pick History
       </span>
       <span class="flex items-center gap-2 !text-sm text-base-foreground-muted">
-        {history.length} / 50
+        {history.length} / {MAX_PICK_HISTORY_ENTRIES}
         <span class="details-chevron" aria-hidden="true">›</span>
       </span>
     </summary>

--- a/frontend/src/utils/cacher.ts
+++ b/frontend/src/utils/cacher.ts
@@ -11,12 +11,20 @@ export type CachedInput = {
 const rangeKey: string = 'lastDiff';
 const activityKey: string = 'pickActivity';
 const historyKey: string = "pickHistory";
-const maxHistoryEntries = 50;
+const historyExclusionKey: string = "pickHistoryExclusionEnabled";
+const pickHistoryVersion = 1;
+
+export const MAX_PICK_HISTORY_ENTRIES = 20;
 
 export type PickActivity = Record<string, number>;
 export type PickHistoryEntry = Problem & {
   entryId: string;
   pickedAt: string;
+};
+
+type PickHistoryStorage = {
+  version: typeof pickHistoryVersion;
+  entries: PickHistoryEntry[];
 };
 
 export const cacheInput = (input: CachedInput): void => {
@@ -105,6 +113,18 @@ const isPickHistoryEntry = (value: unknown): value is PickHistoryEntry => {
   );
 };
 
+const savePickHistory = (history: PickHistoryEntry[]): PickHistoryEntry[] => {
+  const entries = history.slice(0, MAX_PICK_HISTORY_ENTRIES);
+  const storedHistory: PickHistoryStorage = {
+    version: pickHistoryVersion,
+    entries,
+  };
+
+  localStorage.setItem(historyKey, JSON.stringify(storedHistory));
+
+  return entries;
+};
+
 export const loadPickHistory = (): PickHistoryEntry[] => {
   const data = localStorage.getItem(historyKey);
 
@@ -114,12 +134,31 @@ export const loadPickHistory = (): PickHistoryEntry[] => {
 
   try {
     const parsed: unknown = JSON.parse(data);
+    const isLegacyHistory = Array.isArray(parsed);
+    const storedEntries = isLegacyHistory
+      ? parsed
+      : typeof parsed === "object" &&
+          parsed !== null &&
+          "version" in parsed &&
+          parsed.version === pickHistoryVersion &&
+          "entries" in parsed &&
+          Array.isArray(parsed.entries)
+        ? parsed.entries
+        : null;
 
-    if (!Array.isArray(parsed)) {
+    if (storedEntries === null) {
       return [];
     }
 
-    return parsed.filter(isPickHistoryEntry).slice(0, maxHistoryEntries);
+    const history = storedEntries
+      .filter(isPickHistoryEntry)
+      .slice(0, MAX_PICK_HISTORY_ENTRIES);
+
+    if (isLegacyHistory) {
+      savePickHistory(history);
+    }
+
+    return history;
   } catch {
     return [];
   }
@@ -134,14 +173,9 @@ export const recordPickHistory = (
     entryId: `${date.getTime()}-${Math.random().toString(36).slice(2)}`,
     pickedAt: date.toISOString(),
   };
-  const nextHistory = [entry, ...loadPickHistory()].slice(
-    0,
-    maxHistoryEntries,
-  );
+  const nextHistory = [entry, ...loadPickHistory()];
 
-  localStorage.setItem(historyKey, JSON.stringify(nextHistory));
-
-  return nextHistory;
+  return savePickHistory(nextHistory);
 };
 
 export const removePickHistoryEntry = (entryId: string): PickHistoryEntry[] => {
@@ -149,13 +183,20 @@ export const removePickHistoryEntry = (entryId: string): PickHistoryEntry[] => {
     (entry) => entry.entryId !== entryId,
   );
 
-  localStorage.setItem(historyKey, JSON.stringify(nextHistory));
-
-  return nextHistory;
+  return savePickHistory(nextHistory);
 };
 
 export const clearPickHistory = (): PickHistoryEntry[] => {
   localStorage.removeItem(historyKey);
 
   return [];
+};
+
+export const loadHistoryExclusionEnabled = (): boolean =>
+  localStorage.getItem(historyExclusionKey) !== "false";
+
+export const saveHistoryExclusionEnabled = (enabled: boolean): boolean => {
+  localStorage.setItem(historyExclusionKey, String(enabled));
+
+  return enabled;
 };

--- a/frontend/tests/cacher.test.ts
+++ b/frontend/tests/cacher.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  MAX_PICK_HISTORY_ENTRIES,
+  clearPickHistory,
+  loadHistoryExclusionEnabled,
+  loadPickHistory,
+  recordPickHistory,
+  removePickHistoryEntry,
+  saveHistoryExclusionEnabled,
+  type PickHistoryEntry,
+} from "../src/utils/cacher";
+import type { Problem } from "../src/utils/types";
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+const problem = (index: number): Problem => ({
+  id: `abc${String(index).padStart(3, "0")}_a`,
+  contest_id: `abc${String(index).padStart(3, "0")}`,
+  name: `Problem ${index}`,
+  difficulty: 100 + index,
+});
+
+const historyEntry = (index: number): PickHistoryEntry => ({
+  ...problem(index),
+  entryId: `entry-${index}`,
+  pickedAt: new Date(2026, 0, index + 1).toISOString(),
+});
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+  });
+});
+
+describe("pick history", () => {
+  test("keeps only the latest twenty entries", () => {
+    for (let index = 0; index <= MAX_PICK_HISTORY_ENTRIES; index += 1) {
+      recordPickHistory(problem(index), new Date(2026, 0, index + 1));
+    }
+
+    const history = loadPickHistory();
+
+    expect(history).toHaveLength(MAX_PICK_HISTORY_ENTRIES);
+    expect(history[0]?.id).toBe("abc020_a");
+    expect(history.at(-1)?.id).toBe("abc001_a");
+  });
+
+  test("migrates the legacy array format and trims it to twenty entries", () => {
+    const legacyHistory = Array.from({ length: 25 }, (_, index) =>
+      historyEntry(index),
+    );
+    localStorage.setItem("pickHistory", JSON.stringify(legacyHistory));
+
+    const history = loadPickHistory();
+    const stored = JSON.parse(localStorage.getItem("pickHistory") ?? "null");
+
+    expect(history).toHaveLength(MAX_PICK_HISTORY_ENTRIES);
+    expect(stored.version).toBe(1);
+    expect(stored.entries).toHaveLength(MAX_PICK_HISTORY_ENTRIES);
+  });
+
+  test("ignores malformed and unsupported history data", () => {
+    localStorage.setItem("pickHistory", "not-json");
+    expect(loadPickHistory()).toEqual([]);
+
+    localStorage.setItem(
+      "pickHistory",
+      JSON.stringify({ version: 999, entries: [historyEntry(1)] }),
+    );
+    expect(loadPickHistory()).toEqual([]);
+  });
+
+  test("removes one entry or clears the complete history", () => {
+    const first = recordPickHistory(problem(1), new Date(2026, 0, 1));
+    const second = recordPickHistory(problem(2), new Date(2026, 0, 2));
+
+    expect(removePickHistoryEntry(second[0]!.entryId)).toEqual([first[0]]);
+    expect(clearPickHistory()).toEqual([]);
+    expect(loadPickHistory()).toEqual([]);
+  });
+});
+
+describe("history exclusion setting", () => {
+  test("is enabled by default and persists both values", () => {
+    expect(loadHistoryExclusionEnabled()).toBe(true);
+
+    saveHistoryExclusionEnabled(false);
+    expect(loadHistoryExclusionEnabled()).toBe(false);
+
+    saveHistoryExclusionEnabled(true);
+    expect(loadHistoryExclusionEnabled()).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

選出履歴を直近20件の重複防止リストとして利用し、同じ問題が短期間に再選出されないようにします。

## 変更内容

- 選出履歴の上限を50件から20件へ変更
- 履歴内の問題IDを抽選候補から除外するAPIパラメータを追加
- 「履歴内の問題を除外」トグルを追加（初期値ON）
- 除外設定をブラウザへ保存し、再読み込み後も復元
- 履歴保存形式をバージョン化し、旧形式から自動移行
- 除外により候補がなくなった場合の専用メッセージを追加
- 除外IDを最大20件に制限し、不正なIDを検証

## 不具合修正

AtCoder Daily Trainingで再利用されたABC/ARC/AGC問題は、問題データ上の`contest_id`が再利用先コンテストへ置き換わる場合があります。その結果、ABC212 A〜Fなどが開催回フィルターから誤って外れていました。

標準コンテストについては問題ID（例：`abc212_a`）から元コンテストを判定し、フィルターと返却URLを元のコンテストへ正規化します。

## ユーザーへの影響

- 履歴内の最大20問は、除外がONの間は再選出されません
- 21問目が追加されると、最古の問題が再び抽選対象になります
- 除外をOFFにすると履歴を維持したまま重複を許可できます
- 履歴から問題を削除すると、その問題は再び抽選対象になります

## 動作確認

- `cargo test`：30 tests passed
- `bun run test`：5 tests passed
- `bun run check`：0 errors / 0 warnings
- `bun run build`：成功
- ABC212でG・Hを除外してもA〜Fが選出されることを実データで確認
- 除外ON時の再選出防止、OFF時の再選出、設定保持を実画面で確認
- 390px幅で横スクロールが発生しないことを確認