### PR TITLE
Add saved problems list

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,6 +6,7 @@
   import Label from "./components/Label.svelte";
   import Message from "./components/Message.svelte";
   import PickHistory from "./components/PickHistory.svelte";
+  import SavedProblems from "./components/SavedProblems.svelte";
 
   import { Loader } from "@lucide/svelte";
   import {
@@ -24,8 +25,12 @@
     removePickHistoryEntry,
     clearPickHistory,
     saveHistoryExclusionEnabled,
+    loadSavedProblems,
+    removeSavedProblem,
+    clearSavedProblems,
     type PickActivity,
     type PickHistoryEntry,
+    type SavedProblem,
   } from "./utils/cacher";
 
   // ============================================================
@@ -75,6 +80,7 @@
   let loading = $state<boolean>(false); // 問題を取得中か否か
   let pickActivity = $state<PickActivity>(loadPickActivity());
   let pickHistory = $state<PickHistoryEntry[]>(loadPickHistory());
+  let savedProblems = $state<SavedProblem[]>(loadSavedProblems());
   let historyExclusionEnabled = $state<boolean>(
     loadHistoryExclusionEnabled(),
   );
@@ -219,6 +225,14 @@
 
   const updateHistoryExclusion = (enabled: boolean): void => {
     historyExclusionEnabled = saveHistoryExclusionEnabled(enabled);
+  };
+
+  const removeProblemFromSavedList = (problemId: string): void => {
+    savedProblems = removeSavedProblem(problemId);
+  };
+
+  const removeAllSavedProblems = (): void => {
+    savedProblems = clearSavedProblems();
   };
 
   function getDateKey(date: Date): string {
@@ -474,6 +488,12 @@
       history={pickHistory}
       onRemove={removeHistoryEntry}
       onClear={removeAllHistory}
+    />
+
+    <SavedProblems
+      {savedProblems}
+      onRemove={removeProblemFromSavedList}
+      onClear={removeAllSavedProblems}
     />
 
     <div class="mt-10 flex w-full flex-col items-center gap-3">

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -26,8 +26,10 @@
     clearPickHistory,
     saveHistoryExclusionEnabled,
     loadSavedProblems,
+    saveProblem,
     removeSavedProblem,
     clearSavedProblems,
+    MAX_SAVED_PROBLEMS,
     type PickActivity,
     type PickHistoryEntry,
     type SavedProblem,
@@ -81,6 +83,12 @@
   let pickActivity = $state<PickActivity>(loadPickActivity());
   let pickHistory = $state<PickHistoryEntry[]>(loadPickHistory());
   let savedProblems = $state<SavedProblem[]>(loadSavedProblems());
+  let savedProblemIds = $derived(
+    new Set(savedProblems.map((problem) => problem.id)),
+  );
+  let savedListIsFull = $derived(
+    savedProblems.length >= MAX_SAVED_PROBLEMS,
+  );
   let historyExclusionEnabled = $state<boolean>(
     loadHistoryExclusionEnabled(),
   );
@@ -229,6 +237,10 @@
 
   const removeProblemFromSavedList = (problemId: string): void => {
     savedProblems = removeSavedProblem(problemId);
+  };
+
+  const addProblemToSavedList = (problem: Problem): void => {
+    savedProblems = saveProblem(problem);
   };
 
   const removeAllSavedProblems = (): void => {
@@ -444,14 +456,28 @@
               </a>
             </p>
 
-            <!-- Diff表示 -->
-            <Button
-              size="tiny"
-              variant="danger"
-              tone="ghost"
-              class="mt-8 w-full sm:w-[13.5rem]"
-              onclick={toggleDialog}>Show Difficulty</Button
-            >
+            <div class="mt-8 grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <!-- Diff表示 -->
+              <Button
+                variant="danger"
+                tone="ghost"
+                class="min-h-11 w-full"
+                onclick={toggleDialog}>Show Difficulty</Button
+              >
+              <Button
+                variant="secondary"
+                tone="solid"
+                class="min-h-11 w-full"
+                disabled={savedProblemIds.has(result.id) || savedListIsFull}
+                onclick={() => addProblemToSavedList(result!)}
+              >
+                {savedProblemIds.has(result.id)
+                  ? "保存済み"
+                  : savedListIsFull
+                    ? "上限到達"
+                    : "保存"}
+              </Button>
+            </div>
             <Dialog
               class="max-w-lg w-[80vw] m-auto"
               enableClose
@@ -486,6 +512,9 @@
 
     <PickHistory
       history={pickHistory}
+      {savedProblemIds}
+      {savedListIsFull}
+      onSave={addProblemToSavedList}
       onRemove={removeHistoryEntry}
       onClear={removeAllHistory}
     />

--- a/frontend/src/components/PickHistory.svelte
+++ b/frontend/src/components/PickHistory.svelte
@@ -92,10 +92,7 @@
                   {entry.name}
                 </a>
                 <p class="mt-1 !text-xs text-base-foreground-muted">
-                  {entry.contest_id.toUpperCase()} · Diff {entry.difficulty === null
-                    ? "不明"
-                    : Math.floor(entry.difficulty)} ·
-                  {formatPickedAt(entry.pickedAt)}
+                  {entry.contest_id.toUpperCase()} · {formatPickedAt(entry.pickedAt)}
                 </p>
               </div>
 

--- a/frontend/src/components/PickHistory.svelte
+++ b/frontend/src/components/PickHistory.svelte
@@ -6,11 +6,21 @@
 
   type Props = {
     history: PickHistoryEntry[];
+    savedProblemIds: Set<string>;
+    savedListIsFull: boolean;
+    onSave: (problem: PickHistoryEntry) => void;
     onRemove: (entryId: string) => void;
     onClear: () => void;
   };
 
-  let { history, onRemove, onClear }: Props = $props();
+  let {
+    history,
+    savedProblemIds,
+    savedListIsFull,
+    onSave,
+    onRemove,
+    onClear,
+  }: Props = $props();
 
   const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
     month: "numeric",
@@ -26,6 +36,14 @@
     if (window.confirm("選出履歴をすべて削除しますか？")) {
       onClear();
     }
+  };
+
+  const saveLabel = (problemId: string): string => {
+    if (savedProblemIds.has(problemId)) {
+      return "保存済み";
+    }
+
+    return savedListIsFull ? "上限到達" : "保存";
   };
 </script>
 
@@ -81,14 +99,25 @@
                 </p>
               </div>
 
-              <button
-                type="button"
-                class="flex min-h-10 shrink-0 cursor-pointer items-center rounded-md px-2 !text-xs text-base-foreground-muted hover:bg-base-container-muted hover:text-base-foreground-default"
-                aria-label={`${entry.name}を履歴から削除`}
-                onclick={() => onRemove(entry.entryId)}
-              >
-                削除
-              </button>
+              <div class="flex shrink-0 flex-col gap-1 sm:flex-row">
+                <button
+                  type="button"
+                  class="flex min-h-11 cursor-pointer items-center rounded-md px-2 !text-xs text-primary hover:bg-primary/10 disabled:cursor-default disabled:opacity-50"
+                  aria-label={`${entry.name}を保存`}
+                  disabled={savedProblemIds.has(entry.id) || savedListIsFull}
+                  onclick={() => onSave(entry)}
+                >
+                  {saveLabel(entry.id)}
+                </button>
+                <button
+                  type="button"
+                  class="flex min-h-11 cursor-pointer items-center rounded-md px-2 !text-xs text-base-foreground-muted hover:bg-base-container-muted hover:text-base-foreground-default"
+                  aria-label={`${entry.name}を履歴から削除`}
+                  onclick={() => onRemove(entry.entryId)}
+                >
+                  削除
+                </button>
+              </div>
             </li>
           {/each}
         </ol>

--- a/frontend/src/components/SavedProblems.svelte
+++ b/frontend/src/components/SavedProblems.svelte
@@ -75,10 +75,7 @@
                   {problem.name}
                 </a>
                 <p class="mt-1 !text-xs leading-relaxed text-base-foreground-muted">
-                  {problem.contest_id.toUpperCase()} · Diff {problem.difficulty === null
-                    ? "不明"
-                    : Math.floor(problem.difficulty)} ·
-                  {formatSavedAt(problem.savedAt)}
+                  {problem.contest_id.toUpperCase()} · {formatSavedAt(problem.savedAt)}
                 </p>
               </div>
 

--- a/frontend/src/components/SavedProblems.svelte
+++ b/frontend/src/components/SavedProblems.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import {
+    MAX_SAVED_PROBLEMS,
+    type SavedProblem,
+  } from "../utils/cacher";
+
+  type Props = {
+    savedProblems: SavedProblem[];
+    onRemove: (problemId: string) => void;
+    onClear: () => void;
+  };
+
+  let { savedProblems, onRemove, onClear }: Props = $props();
+
+  const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const formatSavedAt = (savedAt: string): string =>
+    dateFormatter.format(new Date(savedAt));
+
+  const clearList = (): void => {
+    if (window.confirm("保存リストをすべて削除しますか？")) {
+      onClear();
+    }
+  };
+</script>
+
+<section class="mt-4 w-full" aria-labelledby="saved-problems-heading">
+  <details class="rounded-lg border border-base-stroke-default bg-base-container-default">
+    <summary
+      class="flex min-h-12 cursor-pointer items-center justify-between gap-3 px-4 py-3"
+    >
+      <span id="saved-problems-heading" class="!text-[1rem] font-medium">
+        Saved Problems
+      </span>
+      <span class="flex items-center gap-2 !text-sm text-base-foreground-muted">
+        {savedProblems.length} / {MAX_SAVED_PROBLEMS}
+        <span class="details-chevron" aria-hidden="true">›</span>
+      </span>
+    </summary>
+
+    <div class="border-t border-base-stroke-default px-3 py-3 sm:px-4">
+      {#if savedProblems.length === 0}
+        <p class="py-5 text-center !text-sm text-base-foreground-muted">
+          後で解きたい問題を保存できます。
+        </p>
+      {:else}
+        <div class="mb-3 flex justify-end">
+          <button
+            type="button"
+            class="min-h-11 cursor-pointer rounded-md px-3 py-2 !text-sm text-destructive hover:bg-destructive-on-fill"
+            onclick={clearList}
+          >
+            すべて削除
+          </button>
+        </div>
+
+        <ol class="max-h-96 space-y-2 overflow-y-auto pr-1">
+          {#each savedProblems as problem (problem.id)}
+            <li
+              class="flex items-start gap-3 rounded-md border border-base-stroke-default p-3"
+            >
+              <div class="min-w-0 flex-1">
+                <a
+                  class="block truncate !text-sm font-medium text-primary underline-offset-4 hover:underline"
+                  href={`https://atcoder.jp/contests/${problem.contest_id}/tasks/${problem.id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {problem.name}
+                </a>
+                <p class="mt-1 !text-xs leading-relaxed text-base-foreground-muted">
+                  {problem.contest_id.toUpperCase()} · Diff {problem.difficulty === null
+                    ? "不明"
+                    : Math.floor(problem.difficulty)} ·
+                  {formatSavedAt(problem.savedAt)}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                class="flex min-h-11 shrink-0 cursor-pointer items-center rounded-md px-2 !text-xs text-base-foreground-muted hover:bg-base-container-muted hover:text-base-foreground-default"
+                aria-label={`${problem.name}を保存リストから削除`}
+                onclick={() => onRemove(problem.id)}
+              >
+                削除
+              </button>
+            </li>
+          {/each}
+        </ol>
+      {/if}
+    </div>
+  </details>
+</section>

--- a/frontend/src/utils/cacher.ts
+++ b/frontend/src/utils/cacher.ts
@@ -13,18 +13,29 @@ const activityKey: string = 'pickActivity';
 const historyKey: string = "pickHistory";
 const historyExclusionKey: string = "pickHistoryExclusionEnabled";
 const pickHistoryVersion = 1;
+const savedProblemsKey = "savedProblems";
+const savedProblemsVersion = 1;
 
 export const MAX_PICK_HISTORY_ENTRIES = 20;
+export const MAX_SAVED_PROBLEMS = 255;
 
 export type PickActivity = Record<string, number>;
 export type PickHistoryEntry = Problem & {
   entryId: string;
   pickedAt: string;
 };
+export type SavedProblem = Problem & {
+  savedAt: string;
+};
 
 type PickHistoryStorage = {
   version: typeof pickHistoryVersion;
   entries: PickHistoryEntry[];
+};
+
+type SavedProblemsStorage = {
+  version: typeof savedProblemsVersion;
+  items: SavedProblem[];
 };
 
 export const cacheInput = (input: CachedInput): void => {
@@ -110,6 +121,25 @@ const isPickHistoryEntry = (value: unknown): value is PickHistoryEntry => {
     (entry.difficulty === null ||
       (typeof entry.difficulty === "number" &&
         Number.isFinite(entry.difficulty)))
+  );
+};
+
+const isSavedProblem = (value: unknown): value is SavedProblem => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const item = value as Partial<SavedProblem>;
+
+  return (
+    typeof item.savedAt === "string" &&
+    !Number.isNaN(Date.parse(item.savedAt)) &&
+    typeof item.id === "string" &&
+    typeof item.contest_id === "string" &&
+    typeof item.name === "string" &&
+    (item.difficulty === null ||
+      (typeof item.difficulty === "number" &&
+        Number.isFinite(item.difficulty)))
   );
 };
 
@@ -199,4 +229,88 @@ export const saveHistoryExclusionEnabled = (enabled: boolean): boolean => {
   localStorage.setItem(historyExclusionKey, String(enabled));
 
   return enabled;
+};
+
+const persistSavedProblems = (items: SavedProblem[]): SavedProblem[] => {
+  const storedItems = items.slice(0, MAX_SAVED_PROBLEMS);
+  const storedProblems: SavedProblemsStorage = {
+    version: savedProblemsVersion,
+    items: storedItems,
+  };
+
+  localStorage.setItem(savedProblemsKey, JSON.stringify(storedProblems));
+
+  return storedItems;
+};
+
+export const loadSavedProblems = (): SavedProblem[] => {
+  const data = localStorage.getItem(savedProblemsKey);
+
+  if (!data) {
+    return [];
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(data);
+
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("version" in parsed) ||
+      parsed.version !== savedProblemsVersion ||
+      !("items" in parsed) ||
+      !Array.isArray(parsed.items)
+    ) {
+      return [];
+    }
+
+    const problemIds = new Set<string>();
+
+    return parsed.items.filter(isSavedProblem).filter((problem) => {
+      if (
+        problemIds.size >= MAX_SAVED_PROBLEMS ||
+        problemIds.has(problem.id)
+      ) {
+        return false;
+      }
+
+      problemIds.add(problem.id);
+      return true;
+    });
+  } catch {
+    return [];
+  }
+};
+
+export const saveProblem = (
+  problem: Problem,
+  date = new Date(),
+): SavedProblem[] => {
+  const savedProblems = loadSavedProblems();
+
+  if (
+    savedProblems.length >= MAX_SAVED_PROBLEMS ||
+    savedProblems.some((savedProblem) => savedProblem.id === problem.id)
+  ) {
+    return savedProblems;
+  }
+
+  return persistSavedProblems([
+    {
+      ...problem,
+      savedAt: date.toISOString(),
+    },
+    ...savedProblems,
+  ]);
+};
+
+export const removeSavedProblem = (problemId: string): SavedProblem[] =>
+  persistSavedProblems(
+    loadSavedProblems().filter((problem) => problem.id !== problemId),
+  );
+
+export const clearSavedProblems = (): SavedProblem[] => {
+  localStorage.removeItem(savedProblemsKey);
+
+  return [];
 };

--- a/frontend/tests/cacher.test.ts
+++ b/frontend/tests/cacher.test.ts
@@ -1,13 +1,19 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
   MAX_PICK_HISTORY_ENTRIES,
+  MAX_SAVED_PROBLEMS,
   clearPickHistory,
+  clearSavedProblems,
   loadHistoryExclusionEnabled,
   loadPickHistory,
+  loadSavedProblems,
   recordPickHistory,
   removePickHistoryEntry,
+  removeSavedProblem,
+  saveProblem,
   saveHistoryExclusionEnabled,
   type PickHistoryEntry,
+  type SavedProblem,
 } from "../src/utils/cacher";
 import type { Problem } from "../src/utils/types";
 
@@ -50,6 +56,11 @@ const historyEntry = (index: number): PickHistoryEntry => ({
   ...problem(index),
   entryId: `entry-${index}`,
   pickedAt: new Date(2026, 0, index + 1).toISOString(),
+});
+
+const savedProblem = (index: number): SavedProblem => ({
+  ...problem(index),
+  savedAt: new Date(2026, 0, index + 1).toISOString(),
 });
 
 beforeEach(() => {
@@ -116,5 +127,74 @@ describe("history exclusion setting", () => {
 
     saveHistoryExclusionEnabled(true);
     expect(loadHistoryExclusionEnabled()).toBe(true);
+  });
+});
+
+describe("saved problems", () => {
+  test("saves unique problems in newest-first order", () => {
+    saveProblem(problem(1), new Date(2026, 0, 1));
+    saveProblem(problem(2), new Date(2026, 0, 2));
+    saveProblem(problem(1), new Date(2026, 0, 3));
+
+    const savedProblems = loadSavedProblems();
+
+    expect(savedProblems.map((saved) => saved.id)).toEqual([
+      "abc002_a",
+      "abc001_a",
+    ]);
+    expect(savedProblems[1]?.savedAt).toBe(
+      new Date(2026, 0, 1).toISOString(),
+    );
+  });
+
+  test("refuses the two-hundred-fifty-sixth problem without deleting existing items", () => {
+    for (let index = 0; index < MAX_SAVED_PROBLEMS; index += 1) {
+      saveProblem(problem(index), new Date(2026, 0, index + 1));
+    }
+
+    const beforeLimit = loadSavedProblems();
+    const afterLimit = saveProblem(problem(MAX_SAVED_PROBLEMS));
+
+    expect(beforeLimit).toHaveLength(MAX_SAVED_PROBLEMS);
+    expect(afterLimit).toEqual(beforeLimit);
+    expect(afterLimit.some((saved) => saved.id === "abc255_a")).toBe(false);
+  });
+
+  test("removes one saved problem or clears the complete list", () => {
+    saveProblem(problem(1));
+    saveProblem(problem(2));
+
+    expect(removeSavedProblem("abc002_a").map((saved) => saved.id)).toEqual([
+      "abc001_a",
+    ]);
+    expect(clearSavedProblems()).toEqual([]);
+    expect(loadSavedProblems()).toEqual([]);
+  });
+
+  test("filters invalid items and supports an unknown difficulty", () => {
+    const unknownDifficulty = {
+      ...savedProblem(1),
+      difficulty: null,
+    };
+    localStorage.setItem(
+      "savedProblems",
+      JSON.stringify({
+        version: 1,
+        items: [unknownDifficulty, unknownDifficulty, { id: "invalid" }],
+      }),
+    );
+
+    expect(loadSavedProblems()).toEqual([unknownDifficulty]);
+  });
+
+  test("ignores malformed and unsupported saved problem data", () => {
+    localStorage.setItem("savedProblems", "not-json");
+    expect(loadSavedProblems()).toEqual([]);
+
+    localStorage.setItem(
+      "savedProblems",
+      JSON.stringify({ version: 999, items: [savedProblem(1)] }),
+    );
+    expect(loadSavedProblems()).toEqual([]);
   });
 });


### PR DESCRIPTION
## 概要

ランダム選出した問題や履歴内の問題を、後で解くために保存できる保存リストを追加します。

## 変更内容

- 選出結果とPick Historyへ保存操作を追加
- 最大255件のSaved Problemsリストを追加
- 問題ID単位で重複保存を防止
- 255件到達時は新規保存を拒否し、既存項目を維持
- 保存済み・上限到達状態をボタンへ反映
- 保存日時とAtCoder問題リンクを表示
- 個別削除・全削除に対応
- 履歴と保存リストを独立させ、相互の削除や重複除外へ影響しない構成に変更
- バージョン付き`localStorage`形式を追加
- 不正項目・重複項目・未対応バージョンを安全に処理
- 履歴と保存リストではDifficultyを表示しない

## ユーザーへの影響

- 履歴が20件から外れた問題も保存リストへ残せます
- 保存リストから削除してもPick Historyには残ります
- Pick Historyから削除しても保存リストには残ります
- 保存リストは履歴ベースの重複除外には使用されません

## 動作確認

- `bun run test`：10 tests passed
- `bun run check`：0 errors / 0 warnings
- `bun run build`：成功
- `cargo test`：30 tests passed
- 選出結果・履歴からの保存を実画面で確認
- 重複保存防止、再読み込み後の保持、個別削除を確認
- 保存削除後も履歴件数が変化しないことを確認
- PC・390px幅で横スクロールが発生しないことを確認